### PR TITLE
Feature/fadesign 515 unitdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+#### v0.22.0
+  - add `Normal` to `UnitDate`
+  - add custom marshaling for `UnitDate` using the following logic:
+    - if there is a `Value`, then output the `Value`  
+	  else if the `<unitdate @normal>` attribute is populated,   
+	  then use the `@normal` attribute value converted as follows:  
+      `@normal="dateA/dateB"`  
+        if `dateA == dateB` then `Value = "dateA"`  
+        if `dateA != dateB` then `Value = "dateA-dateB"`
+
 #### v0.21.0
   - add `ArchRef` and `TitleValue` to `ExtRef` type
   - add `Date` to `Creation` type to align with [FADESIGN-29 data model](https://github.com/nyudlts/fadesign_29-data-model/blob/main/models.csv)

--- a/ead/ead.go
+++ b/ead/ead.go
@@ -509,6 +509,7 @@ type TitleStmt struct {
 type UnitDate struct {
 	Type     FilteredString `xml:"type,attr" json:"type,omitempty"`
 	DateChar FilteredString `xml:"datechar,attr" json:"datechar,omitempty"`
+	Normal   FilteredString `xml:"normal,attr" json:"normal,omitempty"`
 
 	Value string `xml:",innerxml" json:"value,omitempty"`
 }

--- a/ead/ead.go
+++ b/ead/ead.go
@@ -5,7 +5,7 @@ package ead
 // Based on: "Data model for parsing EAD <archdesc> elements": https://jira.nyu.edu/jira/browse/FADESIGN-29.
 
 const (
-	Version = "v0.21.0"
+	Version = "v0.22.0"
 )
 
 type EAD struct {

--- a/ead/ead_test.go
+++ b/ead/ead_test.go
@@ -737,3 +737,14 @@ func TestJSONMarshalingWithPresentationElementsInTitleStmtChildren(t *testing.T)
 
 	runiJSONComparisonTest(t, &params)
 }
+
+func TestUnitDateProcessing(t *testing.T) {
+	var params iJSONTestParams
+
+	params.TestName = "UnitDate processing"
+	params.EADFilePath = filepath.Join(tamwagTestFixturePath, "mos_2021-with-test-unitdates.xml")
+	params.JSONReferenceFilePath = filepath.Join(tamwagTestFixturePath, "mos_2021.json")
+	params.JSONErrorFilePath = "./testdata/tmp/failing-unitdate-processing.json"
+
+	runiJSONComparisonTest(t, &params)
+}

--- a/ead/generate.go
+++ b/ead/generate.go
@@ -116,11 +116,14 @@ func writeConvertTextWithTagsCodeToBuffer(w *bytes.Buffer) {
 		"ChronItem":   "getConvertedTextWithTags",
 		"Container":   "getConvertedTextWithTags",
 		"Creation":    "getConvertedTextWithTags",
-		"Date":        "getConvertedTextWithTags",
-		"Dimensions":  "getConvertedTextWithTags",
-		"Event":       "getConvertedTextWithTags",
+		// Do not add DAO because it requires custom marshaling.
+		"Date": "getConvertedTextWithTags",
+		// Do not add DID because it requires custom marshaling.
+		"Dimensions": "getConvertedTextWithTags",
+		"Event":      "getConvertedTextWithTags",
 		// Extent has custom marshaling requirements and is therefore not generated.
-		"Head":         "getConvertedTextWithTags",
+		"Head": "getConvertedTextWithTags",
+		// Do not add IndexEntry because it requires custom marshaling.
 		"Item":         "getConvertedTextWithTags",
 		"LangMaterial": "getConvertedTextWithTags",
 		"LangUsage":    "getConvertedTextWithTags",
@@ -134,7 +137,8 @@ func writeConvertTextWithTagsCodeToBuffer(w *bytes.Buffer) {
 		"Repository": "getConvertedTextWithTags",
 		"Title":      "getConvertedTextWithTagsNoLBConversion",
 		// Do not add TitleProper because it requires custom marshaling.
-		"UnitDate":  "getConvertedTextWithTags",
+		// Do not add TitleStmt   because it requires custom marshaling.
+		// Do not add UnitDate    because it requires custom marshaling.
 		"UnitTitle": "getConvertedTextWithTags",
 	}
 

--- a/ead/marshaljson-generated.go
+++ b/ead/marshaljson-generated.go
@@ -469,28 +469,6 @@ func (title *Title) MarshalJSON() ([]byte, error) {
 	return jsonData, nil
 }
 
-func (unitdate *UnitDate) MarshalJSON() ([]byte, error) {
-	type UnitDateWithTags UnitDate
-
-	result, err := getConvertedTextWithTags(unitdate.Value)
-	if err != nil {
-		return nil, err
-	}
-
-	jsonData, err := json.Marshal(&struct {
-		Value string `json:"value,omitempty"`
-		*UnitDateWithTags
-	}{
-		Value:            string(result),
-		UnitDateWithTags: (*UnitDateWithTags)(unitdate),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return jsonData, nil
-}
-
 func (unittitle *UnitTitle) MarshalJSON() ([]byte, error) {
 	type UnitTitleWithTags UnitTitle
 

--- a/ead/marshaljson.go
+++ b/ead/marshaljson.go
@@ -2,9 +2,13 @@ package ead
 
 import (
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"strings"
 )
+
+var unitDateNormalRegexp = regexp.MustCompile(`(.+)/(.+)`)
+var unitDateNormalExpectedStringSubmatchCount = 3
 
 // Note that this custom marshalling for DID will prevent PhysDesc from having a Value field
 // that is all whitespace if Extent is nil, but won't prevent PhysDesc from having
@@ -237,4 +241,55 @@ func (fnwh *FormattedNoteWithHead) MarshalJSON() ([]byte, error) {
 	}{
 		FormattedNoteWithHeadAlias: (*FormattedNoteWithHeadAlias)(fnwh),
 	})
+}
+
+func (unitdate *UnitDate) MarshalJSON() ([]byte, error) {
+	type UnitDateWithTags UnitDate
+
+	result, err := getConvertedTextWithTags(unitdate.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	// clean up any blank space
+	result = []byte(strings.TrimSpace(string(result)))
+
+	// if result is empty...
+	if len(result) == 0 {
+		// check if we have a date value in Normal
+		if len(strings.TrimSpace(string(unitdate.Normal))) == 0 {
+			// nothing here, so omit this unitdate by setting the
+			// unitdate variable to an empty struct, which will
+			// be omitted during marshaling
+			unitdate = &UnitDate{}
+		} else {
+			// ok, we found something. Let's convert the value...
+			matches := unitDateNormalRegexp.FindStringSubmatch(string(unitdate.Normal))
+
+			if len(matches) < unitDateNormalExpectedStringSubmatchCount {
+				return nil, fmt.Errorf("problem parsing UnitDate.Normal")
+			}
+			// extract the values and configure result accordingly
+			dateA := matches[1]
+			dateB := matches[2]
+
+			if dateA == dateB {
+				result = []byte(dateA)
+			} else {
+				result = []byte(dateA + "-" + dateB)
+			}
+		}
+	}
+	jsonData, err := json.Marshal(&struct {
+		Value string `json:"value,omitempty"`
+		*UnitDateWithTags
+	}{
+		Value:            string(result),
+		UnitDateWithTags: (*UnitDateWithTags)(unitdate),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return jsonData, nil
 }

--- a/ead/testdata/akkasah/ad_mc_030_ref184.json
+++ b/ead/testdata/akkasah/ad_mc_030_ref184.json
@@ -159,7 +159,8 @@
                 {
                     "value": "Circa 1884-1888",
                     "type": "inclusive",
-                    "datechar": "creation"
+                    "datechar": "creation",
+                    "normal": "1884/1888"
                 },
                 {
                     "value": "1888",
@@ -285,7 +286,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000001",
@@ -417,7 +419,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000002",
@@ -547,7 +550,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000003",
@@ -659,7 +663,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000004",
@@ -784,7 +789,8 @@
                                 "unitdate": [
                                     {
                                         "value": "Circa 1881",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1881/1881"
                                     }
                                 ],
                                 "unitid": "ref184_000005",
@@ -930,7 +936,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000006",
@@ -1070,7 +1077,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000007",
@@ -1205,7 +1213,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000008",
@@ -1325,7 +1334,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000009",
@@ -1477,7 +1487,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000010",
@@ -1603,7 +1614,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000011",
@@ -1744,7 +1756,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000012",
@@ -1876,7 +1889,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000013",
@@ -2014,7 +2028,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000014",
@@ -2155,7 +2170,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000015",
@@ -2298,7 +2314,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000016",
@@ -2427,7 +2444,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000017",
@@ -2562,7 +2580,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000018",
@@ -2662,7 +2681,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000019",
@@ -2746,7 +2766,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000020",
@@ -2830,7 +2851,8 @@
                                     {
                                         "value": "Circa 1884 - 1888",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1884/1888"
                                     }
                                 ],
                                 "unitid": "ref184_000021",

--- a/ead/testdata/cbh/arc_212_plymouth_beecher.json
+++ b/ead/testdata/cbh/arc_212_plymouth_beecher.json
@@ -1953,11 +1953,13 @@
             "unitdate": [
                 {
                     "value": "1819-1980",
-                    "type": "inclusive"
+                    "type": "inclusive",
+                    "normal": "1819/1980"
                 },
                 {
                     "value": "1847-1887",
-                    "type": "bulk"
+                    "type": "bulk",
+                    "normal": "1847/1887"
                 }
             ],
             "unitid": "ARC.212",
@@ -2079,7 +2081,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1863",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1863/1863"
                                             }
                                         ],
                                         "unittitle": {
@@ -2109,7 +2112,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1866",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1866/1866"
                                             }
                                         ],
                                         "unittitle": {
@@ -2139,7 +2143,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1865-1867",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1865/1867"
                                             }
                                         ],
                                         "unittitle": {
@@ -2169,7 +2174,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1881-1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1881/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -2199,7 +2205,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1885",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1885/1885"
                                             }
                                         ],
                                         "unittitle": {
@@ -2269,7 +2276,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1847",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1847/1847"
                                             }
                                         ],
                                         "unittitle": {
@@ -2299,7 +2307,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1849",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1849/1849"
                                             }
                                         ],
                                         "unittitle": {
@@ -2329,7 +2338,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1858",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1858/1858"
                                             }
                                         ],
                                         "unittitle": {
@@ -2359,7 +2369,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1878",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1878/1878"
                                             }
                                         ],
                                         "unittitle": {
@@ -2389,7 +2400,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1884",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1884/1884"
                                             }
                                         ],
                                         "unittitle": {
@@ -2419,7 +2431,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1886/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -2449,7 +2462,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1886/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -2479,7 +2493,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1878-1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1878/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -2520,7 +2535,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1867",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1867/1867"
                                             }
                                         ],
                                         "unittitle": {
@@ -2550,7 +2566,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1886/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -2580,7 +2597,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1886/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -2610,7 +2628,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1886/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -2640,7 +2659,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1886/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -2670,7 +2690,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1886/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -2700,7 +2721,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1857, 1942",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1857/1942"
                                             }
                                         ],
                                         "unittitle": {
@@ -2730,7 +2752,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1845-1891",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1845/1891"
                                             }
                                         ],
                                         "unittitle": {
@@ -2760,7 +2783,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1858",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1858/1858"
                                             }
                                         ],
                                         "unittitle": {
@@ -2790,7 +2814,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1862, 1893-1895",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1862/1895"
                                             }
                                         ],
                                         "unittitle": {
@@ -2820,7 +2845,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1881, 1927",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1881/1927"
                                             }
                                         ],
                                         "unittitle": {
@@ -2850,7 +2876,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1886-1896",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1886/1896"
                                             }
                                         ],
                                         "unittitle": {
@@ -2880,7 +2907,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1891",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1891/1891"
                                             }
                                         ],
                                         "unittitle": {
@@ -2910,7 +2938,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1897",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1897/1897"
                                             }
                                         ],
                                         "unittitle": {
@@ -2940,7 +2969,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1898",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1898/1898"
                                             }
                                         ],
                                         "unittitle": {
@@ -2970,7 +3000,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1896-1975",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1896/1975"
                                             }
                                         ],
                                         "unittitle": {
@@ -3000,7 +3031,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1961",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1961/1961"
                                             }
                                         ],
                                         "unittitle": {
@@ -3030,7 +3062,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1880-1911",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1880/1911"
                                             }
                                         ],
                                         "unittitle": {
@@ -3060,7 +3093,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1940",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1940/1940"
                                             }
                                         ],
                                         "unittitle": {
@@ -3119,7 +3153,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1868",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1868/1868"
                                             }
                                         ],
                                         "unittitle": {
@@ -3149,7 +3184,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1886/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -3179,7 +3215,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887-1907",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1907"
                                             }
                                         ],
                                         "unittitle": {
@@ -3209,7 +3246,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1864-1869",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1864/1869"
                                             }
                                         ],
                                         "unittitle": {
@@ -3239,7 +3277,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1866-1876",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1866/1876"
                                             }
                                         ],
                                         "unittitle": {
@@ -3269,7 +3308,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1877",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1877/1877"
                                             }
                                         ],
                                         "unittitle": {
@@ -3299,7 +3339,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1880",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1880/1880"
                                             }
                                         ],
                                         "unittitle": {
@@ -3329,7 +3370,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1883-1884",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1883/1884"
                                             }
                                         ],
                                         "unittitle": {
@@ -3359,7 +3401,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1885-1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1885/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -3389,7 +3432,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1886/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -3419,7 +3463,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1852, 1860-1879",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1852/1879"
                                             }
                                         ],
                                         "unittitle": {
@@ -3449,7 +3494,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1885-1916",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1885/1916"
                                             }
                                         ],
                                         "unittitle": {
@@ -3490,7 +3536,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1858",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1858/1858"
                                             }
                                         ],
                                         "unittitle": {
@@ -3520,7 +3567,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1859",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1859/1859"
                                             }
                                         ],
                                         "unittitle": {
@@ -3550,7 +3598,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1860",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1860/1860"
                                             }
                                         ],
                                         "unittitle": {
@@ -3580,7 +3629,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1861",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1861/1861"
                                             }
                                         ],
                                         "unittitle": {
@@ -3610,7 +3660,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1860-1863",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1860/1863"
                                             }
                                         ],
                                         "unittitle": {
@@ -3640,7 +3691,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1864",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1864/1864"
                                             }
                                         ],
                                         "unittitle": {
@@ -3670,7 +3722,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1865",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1865/1865"
                                             }
                                         ],
                                         "unittitle": {
@@ -3700,7 +3753,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1865",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1865/1865"
                                             }
                                         ],
                                         "unittitle": {
@@ -3730,7 +3784,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1866",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1866/1866"
                                             }
                                         ],
                                         "unittitle": {
@@ -3760,7 +3815,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1867",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1867/1867"
                                             }
                                         ],
                                         "unittitle": {
@@ -3790,7 +3846,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1868",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1868/1868"
                                             }
                                         ],
                                         "unittitle": {
@@ -3820,7 +3877,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1869-1871",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1869/1871"
                                             }
                                         ],
                                         "unittitle": {
@@ -3850,7 +3908,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1860-1869",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1860/1869"
                                             }
                                         ],
                                         "unittitle": {
@@ -3880,7 +3939,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1870-1871",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1870/1871"
                                             }
                                         ],
                                         "unittitle": {
@@ -3910,7 +3970,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1865",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1865/1865"
                                             }
                                         ],
                                         "unittitle": {
@@ -3940,7 +4001,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1865",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1865/1865"
                                             }
                                         ],
                                         "unittitle": {
@@ -3970,7 +4032,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1872",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1872/1872"
                                             }
                                         ],
                                         "unittitle": {
@@ -4000,7 +4063,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1872-1873",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1872/1873"
                                             }
                                         ],
                                         "unittitle": {
@@ -4030,7 +4094,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1873",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1873/1873"
                                             }
                                         ],
                                         "unittitle": {
@@ -4060,7 +4125,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1873",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1873/1873"
                                             }
                                         ],
                                         "unittitle": {
@@ -4090,7 +4156,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1874",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1874/1874"
                                             }
                                         ],
                                         "unittitle": {
@@ -4120,7 +4187,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1874",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1874/1874"
                                             }
                                         ],
                                         "unittitle": {
@@ -4150,7 +4218,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1875",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1875/1875"
                                             }
                                         ],
                                         "unittitle": {
@@ -4180,7 +4249,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1877",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1877/1877"
                                             }
                                         ],
                                         "unittitle": {
@@ -4210,7 +4280,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1877",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1877/1877"
                                             }
                                         ],
                                         "unittitle": {
@@ -4240,7 +4311,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1870-1879",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1870/1879"
                                             }
                                         ],
                                         "unittitle": {
@@ -4270,7 +4342,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1880",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1880/1880"
                                             }
                                         ],
                                         "unittitle": {
@@ -4300,7 +4373,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1880",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1880/1880"
                                             }
                                         ],
                                         "unittitle": {
@@ -4330,7 +4404,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1882, 1883",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1882/1883"
                                             }
                                         ],
                                         "unittitle": {
@@ -4360,7 +4435,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1882",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1882/1882"
                                             }
                                         ],
                                         "unittitle": {
@@ -4390,7 +4466,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1882",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1882/1882"
                                             }
                                         ],
                                         "unittitle": {
@@ -4420,7 +4497,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1882-1883",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1882/1883"
                                             }
                                         ],
                                         "unittitle": {
@@ -4450,7 +4528,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1883",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1883/1883"
                                             }
                                         ],
                                         "unittitle": {
@@ -4480,7 +4559,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1883",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1883/1883"
                                             }
                                         ],
                                         "unittitle": {
@@ -4510,7 +4590,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1883-1884",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1883/1884"
                                             }
                                         ],
                                         "unittitle": {
@@ -4540,7 +4621,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1884",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1884/1884"
                                             }
                                         ],
                                         "unittitle": {
@@ -4570,7 +4652,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1884",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1884/1884"
                                             }
                                         ],
                                         "unittitle": {
@@ -4600,7 +4683,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1884",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1884/1884"
                                             }
                                         ],
                                         "unittitle": {
@@ -4630,7 +4714,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1884",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1884/1884"
                                             }
                                         ],
                                         "unittitle": {
@@ -4660,7 +4745,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1885",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1885/1885"
                                             }
                                         ],
                                         "unittitle": {
@@ -4690,7 +4776,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1885",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1885/1885"
                                             }
                                         ],
                                         "unittitle": {
@@ -4720,7 +4807,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1885",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1885/1885"
                                             }
                                         ],
                                         "unittitle": {
@@ -4750,7 +4838,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1885",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1885/1885"
                                             }
                                         ],
                                         "unittitle": {
@@ -4780,7 +4869,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1885-1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1885/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -4810,7 +4900,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1886/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -4840,7 +4931,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1886/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -4870,7 +4962,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1886/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -4900,7 +4993,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1886-1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1886/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -4930,7 +5024,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -5192,7 +5287,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1856-1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1856/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -5222,7 +5318,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1860-1869",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1860/1869"
                                             }
                                         ],
                                         "unittitle": {
@@ -5252,7 +5349,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1872-1879",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1872/1879"
                                             }
                                         ],
                                         "unittitle": {
@@ -5282,7 +5380,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1848-1849",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1848/1849"
                                             }
                                         ],
                                         "unittitle": {
@@ -5312,7 +5411,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1878-1879",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1878/1879"
                                             }
                                         ],
                                         "unittitle": {
@@ -5342,7 +5442,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1872-1879",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1872/1879"
                                             }
                                         ],
                                         "unittitle": {
@@ -5372,7 +5473,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1840s-1880s",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1840/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -5402,7 +5504,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1861-1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1861/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -5461,7 +5564,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1896",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1896/1896"
                                             }
                                         ],
                                         "unittitle": {
@@ -5491,7 +5595,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1904",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1904/1904"
                                             }
                                         ],
                                         "unittitle": {
@@ -5579,7 +5684,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1886-1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1886/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -5609,7 +5715,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1892",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1892/1892"
                                             }
                                         ],
                                         "unittitle": {
@@ -5639,7 +5746,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1893",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1893/1893"
                                             }
                                         ],
                                         "unittitle": {
@@ -5814,7 +5922,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1877, 1883",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1877/1883"
                                             }
                                         ],
                                         "unittitle": {
@@ -5844,7 +5953,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1860-1864",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1860/1864"
                                             }
                                         ],
                                         "unittitle": {
@@ -5882,7 +5992,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1872-1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1872/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -5939,7 +6050,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1840, 1913, 1927, 1938",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1840/1938"
                                             }
                                         ],
                                         "unittitle": {
@@ -5980,7 +6092,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1860-1885",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1860/1885"
                                             }
                                         ],
                                         "unittitle": {
@@ -6039,7 +6152,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1872",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1872/1872"
                                             }
                                         ],
                                         "unittitle": {
@@ -6069,7 +6183,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1872",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1872/1872"
                                             }
                                         ],
                                         "unittitle": {
@@ -6099,7 +6214,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1872",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1872/1872"
                                             }
                                         ],
                                         "unittitle": {
@@ -6129,7 +6245,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1873",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1873/1873"
                                             }
                                         ],
                                         "unittitle": {
@@ -6159,7 +6276,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1883",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1883/1883"
                                             }
                                         ],
                                         "unittitle": {
@@ -6200,7 +6318,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1850, 1942, 1959",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1850/1959"
                                             }
                                         ],
                                         "unittitle": {
@@ -6230,7 +6349,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1927",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1927/1927"
                                             }
                                         ],
                                         "unittitle": {
@@ -6260,7 +6380,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1819",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1819/1819"
                                             }
                                         ],
                                         "unittitle": {
@@ -6290,7 +6411,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1853",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1853/1853"
                                             }
                                         ],
                                         "unittitle": {
@@ -6320,7 +6442,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1927",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1927/1927"
                                             }
                                         ],
                                         "unittitle": {
@@ -6350,7 +6473,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1927",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1927/1927"
                                             }
                                         ],
                                         "unittitle": {
@@ -6396,7 +6520,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1858-1868",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1858/1869"
                                             }
                                         ],
                                         "unittitle": {
@@ -6437,7 +6562,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1926",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1926/1926"
                                             }
                                         ],
                                         "unittitle": {
@@ -6467,7 +6593,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1885",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1885/1885"
                                             }
                                         ],
                                         "unittitle": {
@@ -6497,7 +6624,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1834-1837",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1834/1837"
                                             }
                                         ],
                                         "unittitle": {
@@ -6527,7 +6655,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1861",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1861/1861"
                                             }
                                         ],
                                         "unittitle": {
@@ -6557,7 +6686,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1863",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1863/1863"
                                             }
                                         ],
                                         "unittitle": {
@@ -6587,7 +6717,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1863,1865",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1863/1865"
                                             }
                                         ],
                                         "unittitle": {
@@ -6617,7 +6748,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1864",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1864/1864"
                                             }
                                         ],
                                         "unittitle": {
@@ -6647,7 +6779,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1865",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1865/1865"
                                             }
                                         ],
                                         "unittitle": {
@@ -6677,7 +6810,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1867",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1867/1867"
                                             }
                                         ],
                                         "unittitle": {
@@ -6707,7 +6841,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1937",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1937/1937"
                                             }
                                         ],
                                         "unittitle": {
@@ -6748,7 +6883,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1875-1876",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1875/1876"
                                             }
                                         ],
                                         "unittitle": {
@@ -6778,7 +6914,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1874-1934",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1874/1934"
                                             }
                                         ],
                                         "unittitle": {
@@ -6808,7 +6945,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1865",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1865/1865"
                                             }
                                         ],
                                         "unittitle": {
@@ -6838,7 +6976,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1920",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1920/1920"
                                             }
                                         ],
                                         "unittitle": {
@@ -6868,7 +7007,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1875",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1875/1875"
                                             }
                                         ],
                                         "unittitle": {
@@ -6898,7 +7038,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1875",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1875/1875"
                                             }
                                         ],
                                         "unittitle": {
@@ -6928,7 +7069,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1874",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1874/1874"
                                             }
                                         ],
                                         "unittitle": {
@@ -6958,7 +7100,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1873-1876",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1873/1876"
                                             }
                                         ],
                                         "unittitle": {
@@ -6988,7 +7131,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1874",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1874/1874"
                                             }
                                         ],
                                         "unittitle": {
@@ -7011,7 +7155,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "August, 1874 - October, 1874"
+                                                "value": "August, 1874 - October, 1874",
+                                                "normal": "1874/1874"
                                             }
                                         ],
                                         "unittitle": {
@@ -7052,7 +7197,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7082,7 +7228,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7112,7 +7259,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7142,7 +7290,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7172,7 +7321,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7202,7 +7352,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7232,7 +7383,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7262,7 +7414,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7292,7 +7445,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7322,7 +7476,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7352,7 +7507,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7382,7 +7538,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7412,7 +7569,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7442,7 +7600,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7472,7 +7631,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7502,7 +7662,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7532,7 +7693,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7562,7 +7724,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7592,7 +7755,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7622,7 +7786,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7652,7 +7817,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7682,7 +7848,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7712,7 +7879,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887-1891",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1891"
                                             }
                                         ],
                                         "unittitle": {
@@ -7742,7 +7910,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7772,7 +7941,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887-1891",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1891"
                                             }
                                         ],
                                         "unittitle": {
@@ -7809,7 +7979,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "1887"
+                                                "value": "1887",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -7850,7 +8021,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1888-1941",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1888/1941"
                                             }
                                         ],
                                         "unittitle": {
@@ -7880,7 +8052,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887-1927",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1927"
                                             }
                                         ],
                                         "unittitle": {
@@ -7910,7 +8083,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1888",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1888/1888"
                                             }
                                         ],
                                         "unittitle": {
@@ -7940,7 +8114,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1891",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1891/1891"
                                             }
                                         ],
                                         "unittitle": {
@@ -7970,7 +8145,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1895, 1897, 1899",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1895/1899"
                                             }
                                         ],
                                         "unittitle": {
@@ -8000,7 +8176,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1903",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1903/1903"
                                             }
                                         ],
                                         "unittitle": {
@@ -8030,7 +8207,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1914, 1917",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1914/1917"
                                             }
                                         ],
                                         "unittitle": {
@@ -8060,7 +8238,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1923, 1927",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1923/1927"
                                             }
                                         ],
                                         "unittitle": {
@@ -8090,7 +8269,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1900",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1900/1900"
                                             }
                                         ],
                                         "unittitle": {
@@ -8120,7 +8300,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1903",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1903/1903"
                                             }
                                         ],
                                         "unittitle": {
@@ -8150,7 +8331,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1904",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1904/1904"
                                             }
                                         ],
                                         "unittitle": {
@@ -8180,7 +8362,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1913, 1914",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1913/1914"
                                             }
                                         ],
                                         "unittitle": {
@@ -8210,7 +8393,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1958",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1958/1958"
                                             }
                                         ],
                                         "unittitle": {
@@ -8240,7 +8424,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1894",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1894/1894"
                                             }
                                         ],
                                         "unittitle": {
@@ -8270,7 +8455,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1904",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1904/1904"
                                             }
                                         ],
                                         "unittitle": {
@@ -8300,7 +8486,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1881-1947",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1881/1947"
                                             }
                                         ],
                                         "unittitle": {
@@ -8330,7 +8517,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1958",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1958/1958"
                                             }
                                         ],
                                         "unittitle": {
@@ -8376,7 +8564,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1927-1935",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1927/1935"
                                             }
                                         ],
                                         "unittitle": {
@@ -8406,7 +8595,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887, 1910-11",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1911"
                                             }
                                         ],
                                         "unittitle": {
@@ -8436,7 +8626,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -8466,7 +8657,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887-1978",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1978"
                                             }
                                         ],
                                         "unittitle": {
@@ -8496,7 +8688,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1913",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1913/1913"
                                             }
                                         ],
                                         "unittitle": {
@@ -8526,7 +8719,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1883-circa 1927",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1883/1927"
                                             }
                                         ],
                                         "unittitle": {
@@ -8556,7 +8750,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1876-1900",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1868/1900"
                                             }
                                         ],
                                         "unittitle": {
@@ -8586,7 +8781,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1871-1913",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1871/1913"
                                             }
                                         ],
                                         "unittitle": {
@@ -8616,7 +8812,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1888-1918",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1888/1918"
                                             }
                                         ],
                                         "unittitle": {
@@ -8646,7 +8843,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1884, 1913-1926",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1884/1926"
                                             }
                                         ],
                                         "unittitle": {
@@ -8676,7 +8874,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1871-1936",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1871/1936"
                                             }
                                         ],
                                         "unittitle": {
@@ -8706,7 +8905,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1932",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1932/1932"
                                             }
                                         ],
                                         "unittitle": {
@@ -8736,7 +8936,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1889-1894",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1889/1894"
                                             }
                                         ],
                                         "unittitle": {
@@ -8768,7 +8969,8 @@
                         "unitdate": [
                             {
                                 "value": "1819-1958",
-                                "type": "inclusive"
+                                "type": "inclusive",
+                                "normal": "1819/1958"
                             }
                         ],
                         "unittitle": {
@@ -8904,7 +9106,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1854, 1867, 1874, 1923",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1854/1923"
                                             }
                                         ],
                                         "unittitle": {
@@ -8934,7 +9137,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1931",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1931/1931"
                                             }
                                         ],
                                         "unittitle": {
@@ -8964,7 +9168,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1940",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1940/1940"
                                             }
                                         ],
                                         "unittitle": {
@@ -8994,7 +9199,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1884, 1895, 1920",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1884/1920"
                                             }
                                         ],
                                         "unittitle": {
@@ -9024,7 +9230,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1876",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1876/1876"
                                             }
                                         ],
                                         "unittitle": {
@@ -9054,7 +9261,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1869-1870",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1869/1870"
                                             }
                                         ],
                                         "unittitle": {
@@ -9084,7 +9292,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1882, 1884, 1920",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1884/1920"
                                             }
                                         ],
                                         "unittitle": {
@@ -9114,7 +9323,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1888-1921",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1888/1921"
                                             }
                                         ],
                                         "unittitle": {
@@ -9144,7 +9354,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1935-1942",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1935/1942"
                                             }
                                         ],
                                         "unittitle": {
@@ -9174,7 +9385,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1958-1963",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1958/1963"
                                             }
                                         ],
                                         "unittitle": {
@@ -9204,7 +9416,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1930, 1936",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1930/1936"
                                             }
                                         ],
                                         "unittitle": {
@@ -9234,7 +9447,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1869-1892",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1869/1892"
                                             }
                                         ],
                                         "unittitle": {
@@ -9264,7 +9478,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1876, 1892, 1937-1938, 1958",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1876/1958"
                                             }
                                         ],
                                         "unittitle": {
@@ -9294,7 +9509,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1900-1937",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1900/1937"
                                             }
                                         ],
                                         "unittitle": {
@@ -9324,7 +9540,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1930-1932, 1934",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1930/1934"
                                             }
                                         ],
                                         "unittitle": {
@@ -9354,7 +9571,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1934-1960",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1934/1960"
                                             }
                                         ],
                                         "unittitle": {
@@ -9384,7 +9602,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1879",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1879/1879"
                                             }
                                         ],
                                         "unittitle": {
@@ -9414,7 +9633,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1877-1895",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1877/1895"
                                             }
                                         ],
                                         "unittitle": {
@@ -9444,7 +9664,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1885-1899",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1885/1899"
                                             }
                                         ],
                                         "unittitle": {
@@ -9474,7 +9695,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1900-1915",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1900/1915"
                                             }
                                         ],
                                         "unittitle": {
@@ -9504,7 +9726,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1916-1922",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1916/1922"
                                             }
                                         ],
                                         "unittitle": {
@@ -9534,7 +9757,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1923",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1923/1923"
                                             }
                                         ],
                                         "unittitle": {
@@ -9564,7 +9788,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1891-1892, 1902-1908",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1891/1908"
                                             }
                                         ],
                                         "unittitle": {
@@ -9594,7 +9819,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1952-1953",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1952/1953"
                                             }
                                         ],
                                         "unittitle": {
@@ -9624,7 +9850,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1895",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1895/1895"
                                             }
                                         ],
                                         "unittitle": {
@@ -9654,7 +9881,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1905, 1907",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1905/1907"
                                             }
                                         ],
                                         "unittitle": {
@@ -9684,7 +9912,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1932",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1932/1932"
                                             }
                                         ],
                                         "unittitle": {
@@ -9714,7 +9943,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1935",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1935/1935"
                                             }
                                         ],
                                         "unittitle": {
@@ -9744,7 +9974,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1980",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1980/1980"
                                             }
                                         ],
                                         "unittitle": {
@@ -9774,7 +10005,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1930s-circa 1940s",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1929/1940"
                                             }
                                         ],
                                         "unittitle": {
@@ -9804,7 +10036,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1910",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1910/1910"
                                             }
                                         ],
                                         "unittitle": {
@@ -9834,7 +10067,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1960s",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1960/1969"
                                             }
                                         ],
                                         "unittitle": {
@@ -9875,7 +10109,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1851-1853, 1931",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1851/1931"
                                             }
                                         ],
                                         "unittitle": {
@@ -9905,7 +10140,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1858",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1858/1858"
                                             }
                                         ],
                                         "unittitle": {
@@ -9935,7 +10171,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1868-1870",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1868/1870"
                                             }
                                         ],
                                         "unittitle": {
@@ -9965,7 +10202,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1889, 1891, 1896-1897, 1903",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1889/1903"
                                             }
                                         ],
                                         "unittitle": {
@@ -9995,7 +10233,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1897",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1897/1897"
                                             }
                                         ],
                                         "unittitle": {
@@ -10025,7 +10264,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1900-1924",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1900/1924"
                                             }
                                         ],
                                         "unittitle": {
@@ -10055,7 +10295,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1904",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1904/1904"
                                             }
                                         ],
                                         "unittitle": {
@@ -10085,7 +10326,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1920",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1920/1920"
                                             }
                                         ],
                                         "unittitle": {
@@ -10115,7 +10357,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1920-1921",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1920/1921"
                                             }
                                         ],
                                         "unittitle": {
@@ -10145,7 +10388,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1923",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1923/1923"
                                             }
                                         ],
                                         "unittitle": {
@@ -10175,7 +10419,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1925-1926, 1931-1933",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1925/1933"
                                             }
                                         ],
                                         "unittitle": {
@@ -10205,7 +10450,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1925, undated",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1925/1925"
                                             }
                                         ],
                                         "unittitle": {
@@ -10235,7 +10481,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1934-1937",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1934/1937"
                                             }
                                         ],
                                         "unittitle": {
@@ -10265,7 +10512,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1925",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1925/1925"
                                             }
                                         ],
                                         "unittitle": {
@@ -10289,7 +10537,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "undated",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1819/1980"
                                             }
                                         ],
                                         "unittitle": {
@@ -10330,7 +10579,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1845-1907",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1845/1907"
                                             }
                                         ],
                                         "unittitle": {
@@ -10360,7 +10610,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1853-1962",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1853/1961"
                                             }
                                         ],
                                         "unittitle": {
@@ -10390,7 +10641,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1859-1882",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1859/1882"
                                             }
                                         ],
                                         "unittitle": {
@@ -10420,7 +10672,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1875",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1875/1875"
                                             }
                                         ],
                                         "unittitle": {
@@ -10450,7 +10703,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1875-1876",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1875/1876"
                                             }
                                         ],
                                         "unittitle": {
@@ -10480,7 +10734,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1879-1880",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1879/1880"
                                             }
                                         ],
                                         "unittitle": {
@@ -10510,7 +10765,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1880",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1880/1880"
                                             }
                                         ],
                                         "unittitle": {
@@ -10540,7 +10796,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1894",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1894/1894"
                                             }
                                         ],
                                         "unittitle": {
@@ -10570,7 +10827,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1904",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1904/1904"
                                             }
                                         ],
                                         "unittitle": {
@@ -10600,7 +10858,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1906",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1906/1906"
                                             }
                                         ],
                                         "unittitle": {
@@ -10630,7 +10889,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1918",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1918/1918"
                                             }
                                         ],
                                         "unittitle": {
@@ -10660,7 +10920,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1923-1925, 1928-1929",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1923/1929"
                                             }
                                         ],
                                         "unittitle": {
@@ -10690,7 +10951,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1939, undated",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1939/1939"
                                             }
                                         ],
                                         "unittitle": {
@@ -10760,7 +11022,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1914-1921",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1914/1921"
                                             }
                                         ],
                                         "unittitle": {
@@ -10790,7 +11053,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1918",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1918/1918"
                                             }
                                         ],
                                         "unittitle": {
@@ -10820,7 +11084,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1934",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1934/1934"
                                             }
                                         ],
                                         "unittitle": {
@@ -10850,7 +11115,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1939",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1939/1939"
                                             }
                                         ],
                                         "unittitle": {
@@ -10880,7 +11146,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1937",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1937/1937"
                                             }
                                         ],
                                         "unittitle": {
@@ -10910,7 +11177,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1863-1904",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1868/1904"
                                             }
                                         ],
                                         "unittitle": {
@@ -10940,7 +11208,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1873",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1873/1873"
                                             }
                                         ],
                                         "unittitle": {
@@ -10970,7 +11239,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1869-1891",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1869/1891"
                                             }
                                         ],
                                         "unittitle": {
@@ -11000,7 +11270,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1877-1881, 1891",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1877/1891"
                                             }
                                         ],
                                         "unittitle": {
@@ -11030,7 +11301,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1900",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1900/1900"
                                             }
                                         ],
                                         "unittitle": {
@@ -11060,7 +11332,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1899-1929",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1899/1929"
                                             }
                                         ],
                                         "unittitle": {
@@ -11090,7 +11363,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1920-1934",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1920/1934"
                                             }
                                         ],
                                         "unittitle": {
@@ -11120,7 +11394,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1934-1935",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1934/1935"
                                             }
                                         ],
                                         "unittitle": {
@@ -11150,7 +11425,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1889, undated",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1889/1889"
                                             }
                                         ],
                                         "unittitle": {
@@ -11180,7 +11456,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1917",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1917/1917"
                                             }
                                         ],
                                         "unittitle": {
@@ -11210,7 +11487,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1900",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1900/1900"
                                             }
                                         ],
                                         "unittitle": {
@@ -11240,7 +11518,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1945",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1945/1945"
                                             }
                                         ],
                                         "unittitle": {
@@ -11270,7 +11549,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1871",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1871/1871"
                                             }
                                         ],
                                         "unittitle": {
@@ -11300,7 +11580,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -11330,7 +11611,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1896-1902",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1896/1902"
                                             }
                                         ],
                                         "unittitle": {
@@ -11360,7 +11642,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1917",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1917/1917"
                                             }
                                         ],
                                         "unittitle": {
@@ -11390,7 +11673,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1940",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1940/1940"
                                             }
                                         ],
                                         "unittitle": {
@@ -11420,7 +11704,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1940",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1940/1940"
                                             }
                                         ],
                                         "unittitle": {
@@ -11450,7 +11735,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1940",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1940/1940"
                                             }
                                         ],
                                         "unittitle": {
@@ -11480,7 +11766,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1940",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1940/1940"
                                             }
                                         ],
                                         "unittitle": {
@@ -11510,7 +11797,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1940",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1940/1940"
                                             }
                                         ],
                                         "unittitle": {
@@ -11540,7 +11828,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1940",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1940/1940"
                                             }
                                         ],
                                         "unittitle": {
@@ -11570,7 +11859,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1940",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1940/1940"
                                             }
                                         ],
                                         "unittitle": {
@@ -11600,7 +11890,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1940",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1940/1940"
                                             }
                                         ],
                                         "unittitle": {
@@ -11630,7 +11921,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1940-1941",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1940/1941"
                                             }
                                         ],
                                         "unittitle": {
@@ -11660,7 +11952,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1896",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1896/1896"
                                             }
                                         ],
                                         "unittitle": {
@@ -11690,7 +11983,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1949",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1949/1949"
                                             }
                                         ],
                                         "unittitle": {
@@ -11720,7 +12014,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1925-1932",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1925/1932"
                                             }
                                         ],
                                         "unittitle": {
@@ -11750,7 +12045,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1899, 1911-12",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1899/1912"
                                             }
                                         ],
                                         "unittitle": {
@@ -11780,7 +12076,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1927",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1927/1927"
                                             }
                                         ],
                                         "unittitle": {
@@ -11810,7 +12107,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1930",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1930/1930"
                                             }
                                         ],
                                         "unittitle": {
@@ -11840,7 +12138,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1920s",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1920/1920"
                                             }
                                         ],
                                         "unittitle": {
@@ -11870,7 +12169,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1937-1941",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1937/1941"
                                             }
                                         ],
                                         "unittitle": {
@@ -11911,7 +12211,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1890",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1890/1890"
                                             }
                                         ],
                                         "unittitle": {
@@ -11941,7 +12242,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1888-1911",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1888/1911"
                                             }
                                         ],
                                         "unittitle": {
@@ -11971,7 +12273,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1891-1896",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1891/1896"
                                             }
                                         ],
                                         "unittitle": {
@@ -12001,7 +12304,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1895-1922",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1895/1922"
                                             }
                                         ],
                                         "unittitle": {
@@ -12031,7 +12335,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1898",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1898/1898"
                                             }
                                         ],
                                         "unittitle": {
@@ -12072,7 +12377,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1900-1920",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1900/1920"
                                             }
                                         ],
                                         "unittitle": {
@@ -12102,7 +12408,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1918-1919",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1918/1919"
                                             }
                                         ],
                                         "unittitle": {
@@ -12132,7 +12439,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1919-1920",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1919/1920"
                                             }
                                         ],
                                         "unittitle": {
@@ -12162,7 +12470,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1925, 1929, 1953",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1925/1953"
                                             }
                                         ],
                                         "unittitle": {
@@ -12192,7 +12501,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1911-1915",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1911/1915"
                                             }
                                         ],
                                         "unittitle": {
@@ -12222,7 +12532,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1900-1929",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1900/1929"
                                             }
                                         ],
                                         "unittitle": {
@@ -12252,7 +12563,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1899",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1899/1899"
                                             }
                                         ],
                                         "unittitle": {
@@ -12282,7 +12594,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1927",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1927/1927"
                                             }
                                         ],
                                         "unittitle": {
@@ -12312,7 +12625,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1930",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1930/1930"
                                             }
                                         ],
                                         "unittitle": {
@@ -12353,7 +12667,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1925",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1925/1925"
                                             }
                                         ],
                                         "unittitle": {
@@ -12383,7 +12698,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1928",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1928/1928"
                                             }
                                         ],
                                         "unittitle": {
@@ -12413,7 +12729,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1940-1941",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1940/1941"
                                             }
                                         ],
                                         "unittitle": {
@@ -12443,7 +12760,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1938",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1938/1938"
                                             }
                                         ],
                                         "unittitle": {
@@ -12473,7 +12791,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1925-1926, 1937",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1925/1937"
                                             }
                                         ],
                                         "unittitle": {
@@ -12503,7 +12822,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1941",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1941/1941"
                                             }
                                         ],
                                         "unittitle": {
@@ -12544,7 +12864,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1941",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1941/1941"
                                             }
                                         ],
                                         "unittitle": {
@@ -12574,7 +12895,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1941, 1943-1955",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1941/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -12604,7 +12926,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1941-1943",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1941/1943"
                                             }
                                         ],
                                         "unittitle": {
@@ -12634,7 +12957,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1942-1943",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1942/1943"
                                             }
                                         ],
                                         "unittitle": {
@@ -12664,7 +12988,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1941, 1951",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1941/1951"
                                             }
                                         ],
                                         "unittitle": {
@@ -12694,7 +13019,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1941-1942",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1941/1942"
                                             }
                                         ],
                                         "unittitle": {
@@ -12724,7 +13050,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1954",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1954/1954"
                                             }
                                         ],
                                         "unittitle": {
@@ -12754,7 +13081,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1941-circa 1955",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1941/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -12795,7 +13123,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1894",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1894/1894"
                                             }
                                         ],
                                         "unittitle": {
@@ -12825,7 +13154,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1897",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1897/1897"
                                             }
                                         ],
                                         "unittitle": {
@@ -12855,7 +13185,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1904",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1904/1904"
                                             }
                                         ],
                                         "unittitle": {
@@ -12885,7 +13216,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1904",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1904/1904"
                                             }
                                         ],
                                         "unittitle": {
@@ -12915,7 +13247,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1912, 1924",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1912/1924"
                                             }
                                         ],
                                         "unittitle": {
@@ -12945,7 +13278,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1918, undated",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1918/1918"
                                             }
                                         ],
                                         "unittitle": {
@@ -12975,7 +13309,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1920",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1920/1920"
                                             }
                                         ],
                                         "unittitle": {
@@ -13005,7 +13340,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1920-1924",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1920/1924"
                                             }
                                         ],
                                         "unittitle": {
@@ -13035,7 +13371,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1927",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1927/1927"
                                             }
                                         ],
                                         "unittitle": {
@@ -13065,7 +13402,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1932",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1932/1932"
                                             }
                                         ],
                                         "unittitle": {
@@ -13095,7 +13433,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1934",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1934/1934"
                                             }
                                         ],
                                         "unittitle": {
@@ -13125,7 +13464,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1934",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1934/1934"
                                             }
                                         ],
                                         "unittitle": {
@@ -13155,7 +13495,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1937",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1937/1937"
                                             }
                                         ],
                                         "unittitle": {
@@ -13185,7 +13526,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1949",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1949/1949"
                                             }
                                         ],
                                         "unittitle": {
@@ -13215,7 +13557,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1961",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1961/1961"
                                             }
                                         ],
                                         "unittitle": {
@@ -13245,7 +13588,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1862",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1862/1862"
                                             }
                                         ],
                                         "unittitle": {
@@ -13275,7 +13619,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1920",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1920/1920"
                                             }
                                         ],
                                         "unittitle": {
@@ -13305,7 +13650,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1899-1929",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1899/1929"
                                             }
                                         ],
                                         "unittitle": {
@@ -13364,7 +13710,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1934, 1937",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1934/1937"
                                             }
                                         ],
                                         "unittitle": {
@@ -13394,7 +13741,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1894",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1894/1894"
                                             }
                                         ],
                                         "unittitle": {
@@ -13424,7 +13772,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1933",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1933/1933"
                                             }
                                         ],
                                         "unittitle": {
@@ -13454,7 +13803,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1856, 1897-1926",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1856/1926"
                                             }
                                         ],
                                         "unittitle": {
@@ -13484,7 +13834,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1888",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1888/1888"
                                             }
                                         ],
                                         "unittitle": {
@@ -13514,7 +13865,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1876-1918",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1876/1918"
                                             }
                                         ],
                                         "unittitle": {
@@ -13544,7 +13896,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1919-1935",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1919/1935"
                                             }
                                         ],
                                         "unittitle": {
@@ -13574,7 +13927,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1904",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1904/1904"
                                             }
                                         ],
                                         "unittitle": {
@@ -13604,7 +13958,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1920",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1920/1920"
                                             }
                                         ],
                                         "unittitle": {
@@ -13634,7 +13989,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1892",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1892/1892"
                                             }
                                         ],
                                         "unittitle": {
@@ -13664,7 +14020,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1927-1928",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1927/1928"
                                             }
                                         ],
                                         "unittitle": {
@@ -13694,7 +14051,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1901-1902",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1901/1902"
                                             }
                                         ],
                                         "unittitle": {
@@ -13724,7 +14082,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1927, 1970, 1972",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1927/1972"
                                             }
                                         ],
                                         "unittitle": {
@@ -13754,7 +14113,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1941",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1941/1941"
                                             }
                                         ],
                                         "unittitle": {
@@ -13784,7 +14144,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1899-circa 1929",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1899/1929"
                                             }
                                         ],
                                         "unittitle": {
@@ -13814,7 +14175,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1891-1938",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1891/1938"
                                             }
                                         ],
                                         "unittitle": {
@@ -13844,7 +14206,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1859-circa 1935",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1859/1935"
                                             }
                                         ],
                                         "unittitle": {
@@ -13885,7 +14248,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1824, 1970",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1824/1970"
                                             }
                                         ],
                                         "unittitle": {
@@ -13915,7 +14279,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1863",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1863/1863"
                                             }
                                         ],
                                         "unittitle": {
@@ -13945,7 +14310,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1881",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1881/1881"
                                             }
                                         ],
                                         "unittitle": {
@@ -13975,7 +14341,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1886/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -14005,7 +14372,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1902, 1918",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1902/1918"
                                             }
                                         ],
                                         "unittitle": {
@@ -14035,7 +14403,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1886",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1886/1886"
                                             }
                                         ],
                                         "unittitle": {
@@ -14065,7 +14434,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1901-1938",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1901/1938"
                                             }
                                         ],
                                         "unittitle": {
@@ -14095,7 +14465,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1904",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1904/1904"
                                             }
                                         ],
                                         "unittitle": {
@@ -14125,7 +14496,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1913-circa 1919",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1913/1919"
                                             }
                                         ],
                                         "unittitle": {
@@ -14155,7 +14527,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1928",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1928/1928"
                                             }
                                         ],
                                         "unittitle": {
@@ -14185,7 +14558,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1934-1935",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1934/1935"
                                             }
                                         ],
                                         "unittitle": {
@@ -14215,7 +14589,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1978",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1978/1978"
                                             }
                                         ],
                                         "unittitle": {
@@ -14245,7 +14620,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1870, 1911",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1870/1911"
                                             }
                                         ],
                                         "unittitle": {
@@ -14275,7 +14651,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1938-circa 1960s",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1844/1920"
                                             }
                                         ],
                                         "unittitle": {
@@ -14305,7 +14682,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1940",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1940/1940"
                                             }
                                         ],
                                         "unittitle": {
@@ -14335,7 +14713,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1969",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1969/1969"
                                             }
                                         ],
                                         "unittitle": {
@@ -14376,7 +14755,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1874-1887",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1874/1887"
                                             }
                                         ],
                                         "unittitle": {
@@ -14406,7 +14786,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1863-1893",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1863/1893"
                                             }
                                         ],
                                         "unittitle": {
@@ -14436,7 +14817,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1854-circa 1890s",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1854/1890"
                                             }
                                         ],
                                         "unittitle": {
@@ -14466,7 +14848,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1870s-1890s",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1870/1890"
                                             }
                                         ],
                                         "unittitle": {
@@ -14496,7 +14879,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1868-circa 1908",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1868/1908"
                                             }
                                         ],
                                         "unittitle": {
@@ -14526,7 +14910,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1868-circa 1908",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1868/1908"
                                             }
                                         ],
                                         "unittitle": {
@@ -14556,7 +14941,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1901-1902",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1901/1902"
                                             }
                                         ],
                                         "unittitle": {
@@ -14586,7 +14972,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1901-1907",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1901/1907"
                                             }
                                         ],
                                         "unittitle": {
@@ -14616,7 +15003,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "circa 1887-circa 1907, 1916",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1887/1916"
                                             }
                                         ],
                                         "unittitle": {
@@ -14648,7 +15036,8 @@
                         "unitdate": [
                             {
                                 "value": "1824-circa 1980",
-                                "type": "inclusive"
+                                "type": "inclusive",
+                                "normal": "1824/1980"
                             }
                         ],
                         "unittitle": {
@@ -14732,7 +15121,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1840s-1880s",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1840/1880"
                                     }
                                 ],
                                 "unittitle": {
@@ -14762,7 +15152,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1856-circa 1887",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1856/1887"
                                     }
                                 ],
                                 "unittitle": {
@@ -14792,7 +15183,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1840s-1880s",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1840/1887"
                                     }
                                 ],
                                 "unittitle": {
@@ -14822,7 +15214,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1880s",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1880/1880"
                                     }
                                 ],
                                 "unittitle": {
@@ -14852,7 +15245,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1885",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1885/1885"
                                     }
                                 ],
                                 "unittitle": {
@@ -14882,7 +15276,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1880s",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1880/1880"
                                     }
                                 ],
                                 "unittitle": {
@@ -14912,7 +15307,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1884",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1884/1884"
                                     }
                                 ],
                                 "unittitle": {
@@ -14971,7 +15367,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1890",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1890/1890"
                                     }
                                 ],
                                 "unittitle": {
@@ -15001,7 +15398,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1890",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1890/1890"
                                     }
                                 ],
                                 "unittitle": {
@@ -15031,7 +15429,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1887-circa 1897",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1887/1897"
                                     }
                                 ],
                                 "unittitle": {
@@ -15061,7 +15460,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1900, circa 1970",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1900/1970"
                                     }
                                 ],
                                 "unittitle": {
@@ -15091,7 +15491,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1884-circa 1941",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1884/1941"
                                     }
                                 ],
                                 "unittitle": {
@@ -15121,7 +15522,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1886",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1886/1886"
                                     }
                                 ],
                                 "unittitle": {
@@ -15151,7 +15553,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1890s",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1890/1890"
                                     }
                                 ],
                                 "unittitle": {
@@ -15210,7 +15613,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1850s-circa 1890s",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1850/1890"
                                     }
                                 ],
                                 "unittitle": {
@@ -15240,7 +15644,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1850s",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1850/1850"
                                     }
                                 ],
                                 "unittitle": {
@@ -15270,7 +15675,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1850s",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1850/1850"
                                     }
                                 ],
                                 "unittitle": {
@@ -15300,7 +15706,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1902",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1902/1902"
                                     }
                                 ],
                                 "unittitle": {
@@ -15330,7 +15737,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1860",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1860/1860"
                                     }
                                 ],
                                 "unittitle": {
@@ -15359,7 +15767,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1860",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1860/1860"
                                     }
                                 ],
                                 "unittitle": {
@@ -15389,7 +15798,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1863",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1863/1863"
                                     }
                                 ],
                                 "unittitle": {
@@ -15419,7 +15829,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1909",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1909/1909"
                                     }
                                 ],
                                 "unittitle": {
@@ -15449,7 +15860,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1888-circa 1899",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1888/1899"
                                     }
                                 ],
                                 "unittitle": {
@@ -15479,7 +15891,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1940",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1940/1940"
                                     }
                                 ],
                                 "unittitle": {
@@ -15509,7 +15922,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1950s",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1950/1950"
                                     }
                                 ],
                                 "unittitle": {
@@ -15539,7 +15953,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1900",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1900/1900"
                                     }
                                 ],
                                 "unittitle": {
@@ -15569,7 +15984,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1900-circa 1958",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1900/1958"
                                     }
                                 ],
                                 "unittitle": {
@@ -15599,7 +16015,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1950",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1950/1950"
                                     }
                                 ],
                                 "unittitle": {
@@ -15629,7 +16046,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1962",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1962/1962"
                                     }
                                 ],
                                 "unittitle": {
@@ -15659,7 +16077,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1920",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1920/1920"
                                     }
                                 ],
                                 "unittitle": {
@@ -15689,7 +16108,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1920",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1920/1920"
                                     }
                                 ],
                                 "unittitle": {
@@ -15719,7 +16139,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1917-circa 1966",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1917/1966"
                                     }
                                 ],
                                 "unittitle": {
@@ -15749,7 +16170,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1890s",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1890/1890"
                                     }
                                 ],
                                 "unittitle": {
@@ -15779,7 +16201,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1952-circa 1960",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1952/1960"
                                     }
                                 ],
                                 "unittitle": {
@@ -15809,7 +16232,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1955-1956",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1955/1956"
                                     }
                                 ],
                                 "unittitle": {
@@ -15926,7 +16350,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1860s-circa 1902",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1860/1902"
                                     }
                                 ],
                                 "unittitle": {
@@ -15956,7 +16381,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1900-circa 1914",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1900/1914"
                                     }
                                 ],
                                 "unittitle": {
@@ -15980,7 +16406,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1853-circa 1900",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1853/1900"
                                     }
                                 ],
                                 "unittitle": {
@@ -16037,7 +16464,8 @@
                         "unitdate": [
                             {
                                 "value": "circa 1840s-circa 1966",
-                                "type": "inclusive"
+                                "type": "inclusive",
+                                "normal": "1840/1966"
                             }
                         ],
                         "unittitle": {

--- a/ead/testdata/fales/mss_460.json
+++ b/ead/testdata/fales/mss_460.json
@@ -232,7 +232,8 @@
             "unitdate": [
                 {
                     "value": "2015-2016",
-                    "type": "inclusive"
+                    "type": "inclusive",
+                    "normal": "2015/2016"
                 }
             ],
             "unitid": "MSS.460",
@@ -321,7 +322,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "2016",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5743",
@@ -384,7 +386,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5744",
@@ -406,7 +409,8 @@
                                 ],
                                 "unitdate": [
                                     {
-                                        "value": "2016"
+                                        "value": "2016",
+                                        "normal": "2016/2016"
                                     }
                                 ],
                                 "unittitle": {
@@ -462,7 +466,8 @@
                                 ],
                                 "unitdate": [
                                     {
-                                        "value": "2017-ongoing"
+                                        "value": "2017-ongoing",
+                                        "normal": "2017/2017"
                                     }
                                 ],
                                 "unitid": "cuid7032",
@@ -577,7 +582,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5746",
@@ -656,7 +662,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5745",
@@ -719,7 +726,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid7033",
@@ -741,7 +749,8 @@
                                 ],
                                 "unitdate": [
                                     {
-                                        "value": "2016"
+                                        "value": "2016",
+                                        "normal": "2016/2016"
                                     }
                                 ],
                                 "unittitle": {
@@ -823,7 +832,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5749",
@@ -902,7 +912,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5748",
@@ -965,7 +976,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2015"
+                                                "value": "2015",
+                                                "normal": "2015/2015"
                                             }
                                         ],
                                         "unitid": "cuid5750",
@@ -988,7 +1000,8 @@
                                 "unitdate": [
                                     {
                                         "value": "2015-2016",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "2015/2016"
                                     }
                                 ],
                                 "unittitle": {
@@ -1050,7 +1063,8 @@
                                 ],
                                 "unitdate": [
                                     {
-                                        "value": "2016"
+                                        "value": "2016",
+                                        "normal": "2016/2016"
                                     }
                                 ],
                                 "unitid": "cuid7031",
@@ -1133,7 +1147,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5752",
@@ -1212,7 +1227,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5751",
@@ -1275,7 +1291,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5753",
@@ -1297,7 +1314,8 @@
                                 ],
                                 "unitdate": [
                                     {
-                                        "value": "2016"
+                                        "value": "2016",
+                                        "normal": "2016/2016"
                                     }
                                 ],
                                 "unittitle": {
@@ -1379,7 +1397,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5755",
@@ -1458,7 +1477,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5754",
@@ -1521,7 +1541,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5756",
@@ -1543,7 +1564,8 @@
                                 ],
                                 "unitdate": [
                                     {
-                                        "value": "2016"
+                                        "value": "2016",
+                                        "normal": "2016/2016"
                                     }
                                 ],
                                 "unittitle": {
@@ -1625,7 +1647,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2015"
+                                                "value": "2015",
+                                                "normal": "2015/2015"
                                             }
                                         ],
                                         "unitid": "cuid5758",
@@ -1704,7 +1727,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2015"
+                                                "value": "2015",
+                                                "normal": "2015/2015"
                                             }
                                         ],
                                         "unitid": "cuid5757",
@@ -1767,7 +1791,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2015"
+                                                "value": "2015",
+                                                "normal": "2015/2015"
                                             }
                                         ],
                                         "unitid": "cuid5759",
@@ -1789,7 +1814,8 @@
                                 ],
                                 "unitdate": [
                                     {
-                                        "value": "2015"
+                                        "value": "2015",
+                                        "normal": "2015/2015"
                                     }
                                 ],
                                 "unittitle": {
@@ -1871,7 +1897,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5761",
@@ -1950,7 +1977,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5760",
@@ -2013,7 +2041,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5762",
@@ -2035,7 +2064,8 @@
                                 ],
                                 "unitdate": [
                                     {
-                                        "value": "2016"
+                                        "value": "2016",
+                                        "normal": "2016/2016"
                                     }
                                 ],
                                 "unittitle": {
@@ -2117,7 +2147,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5764",
@@ -2196,7 +2227,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5763",
@@ -2259,7 +2291,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2015"
+                                                "value": "2015",
+                                                "normal": "2015/2015"
                                             }
                                         ],
                                         "unitid": "cuid5765",
@@ -2282,7 +2315,8 @@
                                 "unitdate": [
                                     {
                                         "value": "2015-2016",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "2015/2016"
                                     }
                                 ],
                                 "unittitle": {
@@ -2364,7 +2398,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5767",
@@ -2443,7 +2478,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5766",
@@ -2506,7 +2542,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5768",
@@ -2528,7 +2565,8 @@
                                 ],
                                 "unitdate": [
                                     {
-                                        "value": "2016"
+                                        "value": "2016",
+                                        "normal": "2016/2016"
                                     }
                                 ],
                                 "unittitle": {
@@ -2610,7 +2648,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5770",
@@ -2689,7 +2728,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5769",
@@ -2752,7 +2792,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2016"
+                                                "value": "2016",
+                                                "normal": "2016/2016"
                                             }
                                         ],
                                         "unitid": "cuid5771",
@@ -2774,7 +2815,8 @@
                                 ],
                                 "unitdate": [
                                     {
-                                        "value": "2016"
+                                        "value": "2016",
+                                        "normal": "2016/2016"
                                     }
                                 ],
                                 "unittitle": {
@@ -2856,7 +2898,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2015"
+                                                "value": "2015",
+                                                "normal": "2015/2015"
                                             }
                                         ],
                                         "unitid": "cuid5773",
@@ -2935,7 +2978,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2015"
+                                                "value": "2015",
+                                                "normal": "2015/2015"
                                             }
                                         ],
                                         "unitid": "cuid5772",
@@ -2998,7 +3042,8 @@
                                         ],
                                         "unitdate": [
                                             {
-                                                "value": "2015"
+                                                "value": "2015",
+                                                "normal": "2015/2015"
                                             }
                                         ],
                                         "unitid": "cuid5774",
@@ -3020,7 +3065,8 @@
                                 ],
                                 "unitdate": [
                                     {
-                                        "value": "2015"
+                                        "value": "2015",
+                                        "normal": "2015/2015"
                                     }
                                 ],
                                 "unittitle": {

--- a/ead/testdata/nyhs/nyhs_foundling.json
+++ b/ead/testdata/nyhs/nyhs_foundling.json
@@ -842,7 +842,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1968",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1968/1968"
                                     }
                                 ],
                                 "unittitle": {
@@ -871,7 +872,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1969",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1969/1969"
                                     }
                                 ],
                                 "unittitle": {
@@ -900,7 +902,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1970",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1970/1970"
                                     }
                                 ],
                                 "unittitle": {
@@ -929,7 +932,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1971",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1971/1971"
                                     }
                                 ],
                                 "unittitle": {
@@ -958,7 +962,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1972",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1972/1972"
                                     }
                                 ],
                                 "unittitle": {
@@ -987,7 +992,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1973",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1973/1973"
                                     }
                                 ],
                                 "unittitle": {
@@ -1016,7 +1022,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1974",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1974/1974"
                                     }
                                 ],
                                 "unittitle": {
@@ -1045,7 +1052,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1975",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1975/1975"
                                     }
                                 ],
                                 "unittitle": {
@@ -1074,7 +1082,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1976",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1976/1976"
                                     }
                                 ],
                                 "unittitle": {
@@ -1103,7 +1112,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1977",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1977/1977"
                                     }
                                 ],
                                 "unittitle": {
@@ -1412,7 +1422,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1940-1941",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1940/1941"
                                     }
                                 ],
                                 "unittitle": {
@@ -1441,7 +1452,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1942-1944",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1942/1944"
                                     }
                                 ],
                                 "unittitle": {
@@ -1470,7 +1482,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1945-1946",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1945/1946"
                                     }
                                 ],
                                 "unittitle": {
@@ -1499,7 +1512,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1947-1948",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1947/1948"
                                     }
                                 ],
                                 "unittitle": {
@@ -1528,7 +1542,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1949-1950",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1949/1950"
                                     }
                                 ],
                                 "unittitle": {
@@ -1557,7 +1572,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1951-1953",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1951/1953"
                                     }
                                 ],
                                 "unittitle": {
@@ -1586,7 +1602,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1954-1956",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1954/1956"
                                     }
                                 ],
                                 "unittitle": {
@@ -1615,7 +1632,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1957",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1957/1957"
                                     }
                                 ],
                                 "unittitle": {
@@ -1644,7 +1662,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1958",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1958/1958"
                                     }
                                 ],
                                 "unittitle": {
@@ -1673,7 +1692,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1959",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1959/1959"
                                     }
                                 ],
                                 "unittitle": {
@@ -1702,7 +1722,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1960",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1960/1960"
                                     }
                                 ],
                                 "unittitle": {
@@ -1731,7 +1752,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1961",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1961/1961"
                                     }
                                 ],
                                 "unittitle": {
@@ -1760,7 +1782,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1962",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1962/1962"
                                     }
                                 ],
                                 "unittitle": {
@@ -1789,7 +1812,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1963",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1963/1963"
                                     }
                                 ],
                                 "unittitle": {
@@ -1818,7 +1842,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1964",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1964/1964"
                                     }
                                 ],
                                 "unittitle": {
@@ -1847,7 +1872,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1965",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1965/1965"
                                     }
                                 ],
                                 "unittitle": {
@@ -1876,7 +1902,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1966",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1966/1966"
                                     }
                                 ],
                                 "unittitle": {
@@ -1905,7 +1932,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1967",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1967/1967"
                                     }
                                 ],
                                 "unittitle": {
@@ -1934,7 +1962,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1968",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1968/1968"
                                     }
                                 ],
                                 "unittitle": {
@@ -1963,7 +1992,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1969",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1969/1969"
                                     }
                                 ],
                                 "unittitle": {
@@ -1992,7 +2022,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1970",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1970/1970"
                                     }
                                 ],
                                 "unittitle": {
@@ -2021,7 +2052,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1971",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1971/1971"
                                     }
                                 ],
                                 "unittitle": {
@@ -2050,7 +2082,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1972",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1972/1972"
                                     }
                                 ],
                                 "unittitle": {
@@ -2079,7 +2112,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1973",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1973/1973"
                                     }
                                 ],
                                 "unittitle": {
@@ -2108,7 +2142,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1974",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1974/1974"
                                     }
                                 ],
                                 "unittitle": {
@@ -2137,7 +2172,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1975",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1975/1975"
                                     }
                                 ],
                                 "unittitle": {
@@ -2166,7 +2202,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1976",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1976/1976"
                                     }
                                 ],
                                 "unittitle": {
@@ -2195,7 +2232,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1977",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1977/1977"
                                     }
                                 ],
                                 "unittitle": {
@@ -2224,7 +2262,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1978",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1978/1978"
                                     }
                                 ],
                                 "unittitle": {
@@ -2303,7 +2342,8 @@
                         "unitdate": [
                             {
                                 "value": "1869-1978",
-                                "type": "inclusive"
+                                "type": "inclusive",
+                                "normal": "1869/1978"
                             }
                         ],
                         "unittitle": {
@@ -2384,7 +2424,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1870-1883",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1870/1883"
                                             }
                                         ],
                                         "unittitle": {
@@ -2407,7 +2448,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1871-1883",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1871/1883"
                                             }
                                         ],
                                         "unittitle": {
@@ -2430,7 +2472,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1870-1884",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1870/1884"
                                             }
                                         ],
                                         "unittitle": {
@@ -2453,7 +2496,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1884-1895",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1884/1895"
                                             }
                                         ],
                                         "unittitle": {
@@ -2476,7 +2520,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1894-1905",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1894/1905"
                                             }
                                         ],
                                         "unittitle": {
@@ -2499,7 +2544,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1906-1917",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1906/1917"
                                             }
                                         ],
                                         "unittitle": {
@@ -2528,7 +2574,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1885",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1885/1885"
                                             }
                                         ],
                                         "unittitle": {
@@ -2557,7 +2604,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1890-1891",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1890/1891"
                                             }
                                         ],
                                         "unittitle": {
@@ -2586,7 +2634,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1896-1897",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1896/1897"
                                             }
                                         ],
                                         "unittitle": {
@@ -2615,7 +2664,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1898-1899",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1898/1899"
                                             }
                                         ],
                                         "unittitle": {
@@ -2644,7 +2694,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1900-1901",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1900/1901"
                                             }
                                         ],
                                         "unittitle": {
@@ -2673,7 +2724,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1900-1901",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1900/1901"
                                             }
                                         ],
                                         "unittitle": {
@@ -2702,7 +2754,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1902-1903",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1902/1903"
                                             }
                                         ],
                                         "unittitle": {
@@ -2731,7 +2784,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1904-1905",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1904/1905"
                                             }
                                         ],
                                         "unittitle": {
@@ -2760,7 +2814,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1908-1909",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1908/1909"
                                             }
                                         ],
                                         "unittitle": {
@@ -2789,7 +2844,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1916-1917",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1916/1917"
                                             }
                                         ],
                                         "unittitle": {
@@ -2818,7 +2874,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1918-1919",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1918/1919"
                                             }
                                         ],
                                         "unittitle": {
@@ -2847,7 +2904,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1920-1921",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1920/1921"
                                             }
                                         ],
                                         "unittitle": {
@@ -2876,7 +2934,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1922-1923",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1922/1923"
                                             }
                                         ],
                                         "unittitle": {
@@ -2905,7 +2964,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1924-1925",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1924/1925"
                                             }
                                         ],
                                         "unittitle": {
@@ -2934,7 +2994,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1926-1927",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1926/1927"
                                             }
                                         ],
                                         "unittitle": {
@@ -2963,7 +3024,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1928-1931",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1928/1931"
                                             }
                                         ],
                                         "unittitle": {
@@ -2992,7 +3054,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1928-1931",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1928/1931"
                                             }
                                         ],
                                         "unittitle": {
@@ -3021,7 +3084,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1932-1933",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1932/1933"
                                             }
                                         ],
                                         "unittitle": {
@@ -3050,7 +3114,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1934-1935",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1934/1935"
                                             }
                                         ],
                                         "unittitle": {
@@ -3079,7 +3144,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1944",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1944/1944"
                                             }
                                         ],
                                         "unittitle": {
@@ -3136,7 +3202,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1962",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1962/1962"
                                             }
                                         ],
                                         "unittitle": {
@@ -3249,7 +3316,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1967",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1967/1967"
                                             }
                                         ],
                                         "unittitle": {
@@ -3278,7 +3346,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1969",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1969/1969"
                                             }
                                         ],
                                         "unittitle": {
@@ -3307,7 +3376,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1970",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1970/1970"
                                             }
                                         ],
                                         "unittitle": {
@@ -3336,7 +3406,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1971",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1971/1971"
                                             }
                                         ],
                                         "unittitle": {
@@ -3365,7 +3436,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1972",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1972/1972"
                                             }
                                         ],
                                         "unittitle": {
@@ -3394,7 +3466,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1974",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1974/1974"
                                             }
                                         ],
                                         "unittitle": {
@@ -3423,7 +3496,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1975",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1975/1975"
                                             }
                                         ],
                                         "unittitle": {
@@ -3452,7 +3526,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1977-1978",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1977/1978"
                                             }
                                         ],
                                         "unittitle": {
@@ -3481,7 +3556,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1979",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1979/1979"
                                             }
                                         ],
                                         "unittitle": {
@@ -3510,7 +3586,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1980",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1980/1980"
                                             }
                                         ],
                                         "unittitle": {
@@ -3539,7 +3616,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1981",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1981/1981"
                                             }
                                         ],
                                         "unittitle": {
@@ -3568,7 +3646,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1982",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1982/1982"
                                             }
                                         ],
                                         "unittitle": {
@@ -3597,7 +3676,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1983",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1983/1983"
                                             }
                                         ],
                                         "unittitle": {
@@ -3626,7 +3706,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1984",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1984/1984"
                                             }
                                         ],
                                         "unittitle": {
@@ -3655,7 +3736,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1986",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1986/1986"
                                             }
                                         ],
                                         "unittitle": {
@@ -3684,7 +3766,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1989",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1989/1989"
                                             }
                                         ],
                                         "unittitle": {
@@ -3713,7 +3796,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1990",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1990/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -3742,7 +3826,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1991",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1991/1991"
                                             }
                                         ],
                                         "unittitle": {
@@ -3771,7 +3856,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1992",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1992/1992"
                                             }
                                         ],
                                         "unittitle": {
@@ -3800,7 +3886,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1993",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1993/1993"
                                             }
                                         ],
                                         "unittitle": {
@@ -3829,7 +3916,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1994",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1994/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -3858,7 +3946,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1997",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1997/1997"
                                             }
                                         ],
                                         "unittitle": {
@@ -3887,7 +3976,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1999",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1999/1999"
                                             }
                                         ],
                                         "unittitle": {
@@ -3916,7 +4006,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "2000",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "2000/2000"
                                             }
                                         ],
                                         "unittitle": {
@@ -3984,7 +4075,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1934",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1934/1934"
                                             }
                                         ],
                                         "unittitle": {
@@ -4013,7 +4105,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1935",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1935/1935"
                                             }
                                         ],
                                         "unittitle": {
@@ -4042,7 +4135,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1936",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1936/1936"
                                             }
                                         ],
                                         "unittitle": {
@@ -4071,7 +4165,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1936-1937",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1936/1937"
                                             }
                                         ],
                                         "unittitle": {
@@ -4100,7 +4195,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1942",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1942/1942"
                                             }
                                         ],
                                         "unittitle": {
@@ -4129,7 +4225,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1946",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1946/1946"
                                             }
                                         ],
                                         "unittitle": {
@@ -4158,7 +4255,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1947",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1947/1947"
                                             }
                                         ],
                                         "unittitle": {
@@ -4187,7 +4285,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1948",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1948/1948"
                                             }
                                         ],
                                         "unittitle": {
@@ -4216,7 +4315,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1949",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1949/1949"
                                             }
                                         ],
                                         "unittitle": {
@@ -4245,7 +4345,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1950",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1950/1950"
                                             }
                                         ],
                                         "unittitle": {
@@ -4274,7 +4375,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1951",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1951/1951"
                                             }
                                         ],
                                         "unittitle": {
@@ -4303,7 +4405,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1952",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1952/1952"
                                             }
                                         ],
                                         "unittitle": {
@@ -4332,7 +4435,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1953",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1953/1953"
                                             }
                                         ],
                                         "unittitle": {
@@ -4361,7 +4465,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1954",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1954/1954"
                                             }
                                         ],
                                         "unittitle": {
@@ -4390,7 +4495,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1955",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1955/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -4419,7 +4525,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1956",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1956/1956"
                                             }
                                         ],
                                         "unittitle": {
@@ -4448,7 +4555,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1957",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1957/1957"
                                             }
                                         ],
                                         "unittitle": {
@@ -4477,7 +4585,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1958",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1958/1958"
                                             }
                                         ],
                                         "unittitle": {
@@ -4506,7 +4615,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1959",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1959/1959"
                                             }
                                         ],
                                         "unittitle": {
@@ -4535,7 +4645,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1960",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1960/1960"
                                             }
                                         ],
                                         "unittitle": {
@@ -4564,7 +4675,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1961",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1961/1961"
                                             }
                                         ],
                                         "unittitle": {
@@ -4593,7 +4705,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1962",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1962/1962"
                                             }
                                         ],
                                         "unittitle": {
@@ -4622,7 +4735,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1963",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1963/1963"
                                             }
                                         ],
                                         "unittitle": {
@@ -4651,7 +4765,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1964",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1964/1964"
                                             }
                                         ],
                                         "unittitle": {
@@ -4680,7 +4795,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1965",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1965/1965"
                                             }
                                         ],
                                         "unittitle": {
@@ -4709,7 +4825,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1966",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1966/1966"
                                             }
                                         ],
                                         "unittitle": {
@@ -4738,7 +4855,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1967",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1967/1967"
                                             }
                                         ],
                                         "unittitle": {
@@ -4767,7 +4885,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1968",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1968/1968"
                                             }
                                         ],
                                         "unittitle": {
@@ -4796,7 +4915,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1969",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1969/1969"
                                             }
                                         ],
                                         "unittitle": {
@@ -4825,7 +4945,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1972",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1972/1972"
                                             }
                                         ],
                                         "unittitle": {
@@ -4921,7 +5042,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1900-1907",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1900/1907"
                                             }
                                         ],
                                         "unittitle": {
@@ -4950,7 +5072,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1908-1913",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1908/1913"
                                             }
                                         ],
                                         "unittitle": {
@@ -4979,7 +5102,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1915-1918",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1915/1918"
                                             }
                                         ],
                                         "unittitle": {
@@ -5008,7 +5132,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1919-1928",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1919/1928"
                                             }
                                         ],
                                         "unittitle": {
@@ -5037,7 +5162,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1900-1910",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1900/1910"
                                             }
                                         ],
                                         "unittitle": {
@@ -5066,7 +5192,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1930-1944",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1930/1944"
                                             }
                                         ],
                                         "unittitle": {
@@ -5095,7 +5222,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1901-1912",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1901/1912"
                                             }
                                         ],
                                         "unittitle": {
@@ -5124,7 +5252,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1913-1917",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1913/1917"
                                             }
                                         ],
                                         "unittitle": {
@@ -5153,7 +5282,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1918-1927",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1918/1927"
                                             }
                                         ],
                                         "unittitle": {
@@ -5182,7 +5312,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1929-1932",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1929/1932"
                                             }
                                         ],
                                         "unittitle": {
@@ -5211,7 +5342,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1927-1932",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1927/1932"
                                             }
                                         ],
                                         "unittitle": {
@@ -5240,7 +5372,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1932-1935",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1932/1935"
                                             }
                                         ],
                                         "unittitle": {
@@ -5269,7 +5402,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1937-1945",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1937/1945"
                                             }
                                         ],
                                         "unittitle": {
@@ -5298,7 +5432,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1944-1945",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1944/1945"
                                             }
                                         ],
                                         "unittitle": {
@@ -5327,7 +5462,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1951-1952",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1951/1952"
                                             }
                                         ],
                                         "unittitle": {
@@ -5384,7 +5520,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1952-1953",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1952/1953"
                                             }
                                         ],
                                         "unittitle": {
@@ -5438,7 +5575,8 @@
                         "unitdate": [
                             {
                                 "value": "1869-2000",
-                                "type": "inclusive"
+                                "type": "inclusive",
+                                "normal": "1869/2000"
                             }
                         ],
                         "unittitle": {
@@ -5499,7 +5637,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1869-1910",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1869/1910"
                                     }
                                 ],
                                 "unittitle": {
@@ -5696,7 +5835,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1874",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1874/1874"
                                     }
                                 ],
                                 "unittitle": {
@@ -5809,7 +5949,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1886-1935",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1886/1935"
                                     }
                                 ],
                                 "unittitle": {
@@ -5866,7 +6007,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1889-1941",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1889/1941"
                                     }
                                 ],
                                 "unittitle": {
@@ -5923,7 +6065,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1891",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1891/1891"
                                     }
                                 ],
                                 "unittitle": {
@@ -5952,7 +6095,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1893-1922",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1893/1922"
                                     }
                                 ],
                                 "unittitle": {
@@ -5981,7 +6125,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1897-1988",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1897/1988"
                                     }
                                 ],
                                 "unittitle": {
@@ -6206,7 +6351,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1911-1917",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1911/1917"
                                     }
                                 ],
                                 "unittitle": {
@@ -6235,7 +6381,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1911-1935",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1911/1935"
                                     }
                                 ],
                                 "unittitle": {
@@ -6600,7 +6747,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1934",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1934/1934"
                                     }
                                 ],
                                 "unittitle": {
@@ -6825,7 +6973,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1947",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1947/1947"
                                     }
                                 ],
                                 "unittitle": {
@@ -7022,7 +7171,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1950",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1950/1950"
                                     }
                                 ],
                                 "unittitle": {
@@ -7247,7 +7397,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1958-1964",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1958/1964"
                                     }
                                 ],
                                 "unittitle": {
@@ -7276,7 +7427,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1958-1979",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1958/1979"
                                     }
                                 ],
                                 "unittitle": {
@@ -7417,7 +7569,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1960",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1960/1960"
                                     }
                                 ],
                                 "unittitle": {
@@ -7446,7 +7599,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1961-1965",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1961/1965"
                                     }
                                 ],
                                 "unittitle": {
@@ -7503,7 +7657,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1966-1974",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1966/1974"
                                     }
                                 ],
                                 "unittitle": {
@@ -7526,7 +7681,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1970-1973",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1970/1973"
                                     }
                                 ],
                                 "unittitle": {
@@ -7549,7 +7705,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1971-1978",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1971/1978"
                                     }
                                 ],
                                 "unittitle": {
@@ -7578,7 +7735,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1972-1974",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1972/1974"
                                     }
                                 ],
                                 "unittitle": {
@@ -7741,7 +7899,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1974-1979",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1974/1979"
                                     }
                                 ],
                                 "unittitle": {
@@ -7770,7 +7929,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1975",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1975/1975"
                                     }
                                 ],
                                 "unittitle": {
@@ -7799,7 +7959,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1975",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1975/1975"
                                     }
                                 ],
                                 "unittitle": {
@@ -8108,7 +8269,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1980-1989",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1980/1989"
                                     }
                                 ],
                                 "unittitle": {
@@ -8663,7 +8825,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1987",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1987/1987"
                                     }
                                 ],
                                 "unittitle": {
@@ -8972,7 +9135,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1989",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1989/1989"
                                     }
                                 ],
                                 "unittitle": {
@@ -9057,7 +9221,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1990-1993",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1990/1993"
                                     }
                                 ],
                                 "unittitle": {
@@ -9086,7 +9251,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1990-1995",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1990/1995"
                                     }
                                 ],
                                 "unittitle": {
@@ -9199,7 +9365,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1991-1996",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1991/1996"
                                     }
                                 ],
                                 "unittitle": {
@@ -9256,7 +9423,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1994/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -9593,7 +9761,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1998",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1998/1998"
                                     }
                                 ],
                                 "unittitle": {
@@ -9774,7 +9943,8 @@
                         "unitdate": [
                             {
                                 "value": "1869-2004",
-                                "type": "inclusive"
+                                "type": "inclusive",
+                                "normal": "1869/2004"
                             }
                         ],
                         "unittitle": {
@@ -9889,7 +10059,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1977",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1977/1977"
                                             }
                                         ],
                                         "unittitle": {
@@ -10414,7 +10585,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1980",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1980/1980"
                                             }
                                         ],
                                         "unittitle": {
@@ -10616,7 +10788,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1940",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1940/1940"
                                             }
                                         ],
                                         "unittitle": {
@@ -10645,7 +10818,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1941",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1941/1941"
                                             }
                                         ],
                                         "unittitle": {
@@ -10674,7 +10848,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1942",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1942/1942"
                                             }
                                         ],
                                         "unittitle": {
@@ -10703,7 +10878,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1943",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1943/1943"
                                             }
                                         ],
                                         "unittitle": {
@@ -10732,7 +10908,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1944",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1944/1944"
                                             }
                                         ],
                                         "unittitle": {
@@ -10761,7 +10938,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1945",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1945/1945"
                                             }
                                         ],
                                         "unittitle": {
@@ -10818,7 +10996,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1950-1998",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1950/1998"
                                             }
                                         ],
                                         "unittitle": {
@@ -10892,7 +11071,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1973-1976",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1973/1976"
                                             }
                                         ],
                                         "unittitle": {
@@ -10921,7 +11101,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1977-1979",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1977/1979"
                                             }
                                         ],
                                         "unittitle": {
@@ -10950,7 +11131,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1980-1982",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1980/1982"
                                             }
                                         ],
                                         "unittitle": {
@@ -10979,7 +11161,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1983-1988",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1983/1988"
                                             }
                                         ],
                                         "unittitle": {
@@ -11120,7 +11303,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1986-1988",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1986/1988"
                                             }
                                         ],
                                         "unittitle": {
@@ -11149,7 +11333,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1985-1991",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1985/1991"
                                             }
                                         ],
                                         "unittitle": {
@@ -11290,7 +11475,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1995",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1995/1995"
                                             }
                                         ],
                                         "unittitle": {
@@ -11767,7 +11953,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1999-2000",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1999/2000"
                                             }
                                         ],
                                         "unittitle": {
@@ -11818,7 +12005,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1999",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1999/1999"
                                             }
                                         ],
                                         "unittitle": {
@@ -11908,7 +12096,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1990-1999",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1990/1999"
                                             }
                                         ],
                                         "unittitle": {
@@ -12143,7 +12332,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1979-1984",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1979/1984"
                                             }
                                         ],
                                         "unittitle": {
@@ -12199,7 +12389,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1972-1989",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1972/1989"
                                             }
                                         ],
                                         "unittitle": {
@@ -12759,7 +12950,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1977",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1977/1977"
                                             }
                                         ],
                                         "unittitle": {
@@ -13011,7 +13203,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1949-1977",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1949/1977"
                                             }
                                         ],
                                         "unittitle": {
@@ -13096,7 +13289,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1963-2005",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1963/2005"
                                             }
                                         ],
                                         "unittitle": {
@@ -13119,7 +13313,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1964",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1964/1964"
                                             }
                                         ],
                                         "unittitle": {
@@ -13198,7 +13393,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1973",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1973/1973"
                                             }
                                         ],
                                         "unittitle": {
@@ -13255,7 +13451,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1976-1978",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1976/1978"
                                             }
                                         ],
                                         "unittitle": {
@@ -13340,7 +13537,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1978-1982",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1978/1982"
                                             }
                                         ],
                                         "unittitle": {
@@ -13453,7 +13651,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1985-1989",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1985/1989"
                                             }
                                         ],
                                         "unittitle": {
@@ -13560,7 +13759,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1991",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1991/1991"
                                             }
                                         ],
                                         "unittitle": {
@@ -13589,7 +13789,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1996-2005",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1996/2005"
                                             }
                                         ],
                                         "unittitle": {
@@ -13618,7 +13819,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1998",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1998/1998"
                                             }
                                         ],
                                         "unittitle": {
@@ -13731,7 +13933,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "2000-2005",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "2000/2005"
                                             }
                                         ],
                                         "unittitle": {
@@ -14612,7 +14815,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1991-1994",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1991/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -15294,7 +15498,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1977-1982",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1977/1982"
                                             }
                                         ],
                                         "unittitle": {
@@ -15855,7 +16060,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1941",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1941/1941"
                                             }
                                         ],
                                         "unittitle": {
@@ -16743,7 +16949,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1936-1953",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1936/1953"
                                             }
                                         ],
                                         "unittitle": {
@@ -17265,7 +17472,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1994-1995",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1994/1995"
                                             }
                                         ],
                                         "unittitle": {
@@ -17294,7 +17502,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1997-1998",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1997/1998"
                                             }
                                         ],
                                         "unittitle": {
@@ -17351,7 +17560,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1994-2002",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1994/2002"
                                             }
                                         ],
                                         "unittitle": {
@@ -17572,7 +17782,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1997-2001",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1997/2001"
                                             }
                                         ],
                                         "unittitle": {
@@ -17824,7 +18035,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1992-1997",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1992/1997"
                                             }
                                         ],
                                         "unittitle": {
@@ -18073,7 +18285,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1945-1999",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1945/1999"
                                             }
                                         ],
                                         "unittitle": {
@@ -18102,7 +18315,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1960-1999",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1960/1999"
                                             }
                                         ],
                                         "unittitle": {
@@ -19059,7 +19273,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1910-1929",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1910/1929"
                                             }
                                         ],
                                         "unittitle": {
@@ -19623,7 +19838,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1976-1980",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1976/1980"
                                             }
                                         ],
                                         "unittitle": {
@@ -20440,7 +20656,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1993-1994",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1993/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -20838,7 +21055,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1884-1973",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1884/1973"
                                     }
                                 ],
                                 "unittitle": {
@@ -21157,7 +21375,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1936-1943",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1936/1943"
                                             }
                                         ],
                                         "unittitle": {
@@ -21186,7 +21405,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1944-1951",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1944/1951"
                                             }
                                         ],
                                         "unittitle": {
@@ -21215,7 +21435,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1952-1955",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1952/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -21244,7 +21465,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1956-1959",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1956/1959"
                                             }
                                         ],
                                         "unittitle": {
@@ -21273,7 +21495,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1960-1961",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1960/1961"
                                             }
                                         ],
                                         "unittitle": {
@@ -21286,7 +21509,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1887-1977",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1887/1977"
                                     }
                                 ],
                                 "unittitle": {
@@ -21335,7 +21559,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1885-1900",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1885/1900"
                                             }
                                         ],
                                         "unittitle": {
@@ -21358,7 +21583,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1912-1943",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1912/1943"
                                             }
                                         ],
                                         "unittitle": {
@@ -21387,7 +21613,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1933-1939",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1933/1939"
                                             }
                                         ],
                                         "unittitle": {
@@ -21472,7 +21699,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1950-1955",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1950/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -21501,7 +21729,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1905-1933",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1905/1933"
                                             }
                                         ],
                                         "unittitle": {
@@ -21514,7 +21743,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1885-1995",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1885/1995"
                                     }
                                 ],
                                 "unittitle": {
@@ -21575,7 +21805,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1875-1979",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1875/1979"
                                             }
                                         ],
                                         "unittitle": {
@@ -21884,7 +22115,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1952-1964",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1952/1964"
                                             }
                                         ],
                                         "unittitle": {
@@ -22042,7 +22274,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1960-1973",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1960/1973"
                                             }
                                         ],
                                         "unittitle": {
@@ -22788,7 +23021,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1984",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1984/1984"
                                             }
                                         ],
                                         "unittitle": {
@@ -22817,7 +23051,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1984-1999",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1984/1999"
                                             }
                                         ],
                                         "unittitle": {
@@ -22846,7 +23081,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1988-2001",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1988/2001"
                                             }
                                         ],
                                         "unittitle": {
@@ -22875,7 +23111,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1998",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1998/1998"
                                             }
                                         ],
                                         "unittitle": {
@@ -23364,7 +23601,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1875-2001",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1875/2001"
                                     }
                                 ],
                                 "unittitle": {
@@ -23419,7 +23657,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1949-1969",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1949/1969"
                                             }
                                         ],
                                         "unittitle": {
@@ -23448,7 +23687,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1979-1999",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1979/1999"
                                             }
                                         ],
                                         "unittitle": {
@@ -23561,7 +23801,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1972",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1972/1972"
                                             }
                                         ],
                                         "unittitle": {
@@ -23686,7 +23927,8 @@
                         "unitdate": [
                             {
                                 "value": "1875-2001",
-                                "type": "inclusive"
+                                "type": "inclusive",
+                                "normal": "1875/2001"
                             }
                         ],
                         "unittitle": {
@@ -24007,7 +24249,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1956",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1956/1956"
                                     }
                                 ],
                                 "unittitle": {
@@ -24036,7 +24279,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1947-1965",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1947/1965"
                                     }
                                 ],
                                 "unittitle": {
@@ -24065,7 +24309,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1967-1989",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1967/1989"
                                     }
                                 ],
                                 "unittitle": {
@@ -24094,7 +24339,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1950-1997",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1950/1997"
                                     }
                                 ],
                                 "unittitle": {
@@ -24123,7 +24369,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994-2001",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1994/2001"
                                     }
                                 ],
                                 "unittitle": {
@@ -24276,7 +24523,8 @@
                         "unitdate": [
                             {
                                 "value": "1869-2001",
-                                "type": "inclusive"
+                                "type": "inclusive",
+                                "normal": "1869/2001"
                             }
                         ],
                         "unittitle": {
@@ -24341,7 +24589,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1909",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1909/1909"
                                             }
                                         ],
                                         "unittitle": {
@@ -24583,7 +24832,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1969",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1969/1969"
                                             }
                                         ],
                                         "unittitle": {
@@ -24668,7 +24918,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1975",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1975/1975"
                                             }
                                         ],
                                         "unittitle": {
@@ -24787,7 +25038,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1994",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1994/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -24816,7 +25068,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1994",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1994/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -25070,7 +25323,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1909-2007",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1909/2007"
                                     }
                                 ],
                                 "unittitle": {
@@ -25241,7 +25495,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1967-1973",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1967/1973"
                                             }
                                         ],
                                         "unittitle": {
@@ -25298,7 +25553,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1984-1989",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1984/1989"
                                             }
                                         ],
                                         "unittitle": {
@@ -25327,7 +25583,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1990-1991",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1990/1991"
                                             }
                                         ],
                                         "unittitle": {
@@ -25356,7 +25613,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1992-1996",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1992/1996"
                                             }
                                         ],
                                         "unittitle": {
@@ -25385,7 +25643,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1977-1984",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1977/1984"
                                             }
                                         ],
                                         "unittitle": {
@@ -25414,7 +25673,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1985-2001",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1985/2001"
                                             }
                                         ],
                                         "unittitle": {
@@ -25443,7 +25703,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "2003-2008",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "2003/2008"
                                             }
                                         ],
                                         "unittitle": {
@@ -25528,7 +25789,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1998-2000",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1998/2000"
                                             }
                                         ],
                                         "unittitle": {
@@ -25585,7 +25847,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1999",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1999/1999"
                                             }
                                         ],
                                         "unittitle": {
@@ -25614,7 +25877,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "2000",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "2000/2000"
                                             }
                                         ],
                                         "unittitle": {
@@ -25655,7 +25919,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1955-2009",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1955/2009"
                                     }
                                 ],
                                 "unittitle": {
@@ -25741,7 +26006,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1875-1948",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1875/1948"
                                     }
                                 ],
                                 "unittitle": {
@@ -25826,7 +26092,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1919",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1919/1919"
                                     }
                                 ],
                                 "unittitle": {
@@ -26023,7 +26290,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1949",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1949/1949"
                                     }
                                 ],
                                 "unittitle": {
@@ -26052,7 +26320,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1954",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1954/1954"
                                     }
                                 ],
                                 "unittitle": {
@@ -26081,7 +26350,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1959",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1959/1959"
                                     }
                                 ],
                                 "unittitle": {
@@ -26138,7 +26408,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1961-1964",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1961/1964"
                                     }
                                 ],
                                 "unittitle": {
@@ -26195,7 +26466,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1969",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1969/1969"
                                     }
                                 ],
                                 "unittitle": {
@@ -26224,7 +26496,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1969",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1969/1969"
                                     }
                                 ],
                                 "unittitle": {
@@ -26253,7 +26526,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1969",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1969/1969"
                                     }
                                 ],
                                 "unittitle": {
@@ -26282,7 +26556,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1969",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1969/1969"
                                     }
                                 ],
                                 "unittitle": {
@@ -26339,7 +26614,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1980-1988",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1980/1988"
                                     }
                                 ],
                                 "unittitle": {
@@ -26564,7 +26840,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1994/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -26593,7 +26870,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994-1997",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1994/1997"
                                     }
                                 ],
                                 "unittitle": {
@@ -26986,7 +27264,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1993-1998",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1993/1998"
                                     }
                                 ],
                                 "unittitle": {
@@ -27043,7 +27322,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1999",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1999/1999"
                                     }
                                 ],
                                 "unittitle": {
@@ -27084,7 +27364,8 @@
                         "unitdate": [
                             {
                                 "value": "1875-2007",
-                                "type": "inclusive"
+                                "type": "inclusive",
+                                "normal": "1875/2007"
                             }
                         ],
                         "unittitle": {
@@ -27133,7 +27414,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1869-1899",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1869/1899"
                                     }
                                 ],
                                 "unittitle": {
@@ -27162,7 +27444,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1917-1939",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1917/1939"
                                     }
                                 ],
                                 "unittitle": {
@@ -27191,7 +27474,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1941-1956",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1941/1956"
                                     }
                                 ],
                                 "unittitle": {
@@ -27288,7 +27572,8 @@
                         "unitdate": [
                             {
                                 "value": "1869-1994",
-                                "type": "inclusive"
+                                "type": "inclusive",
+                                "normal": "1869/1994"
                             }
                         ],
                         "unittitle": {
@@ -27415,7 +27700,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1992",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1992/1992"
                                     }
                                 ],
                                 "unittitle": {
@@ -27584,7 +27870,8 @@
                                 "unitdate": [
                                     {
                                         "value": "2001",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "2001/2001"
                                     }
                                 ],
                                 "unittitle": {
@@ -28608,7 +28895,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1956",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1956/1956"
                                     }
                                 ],
                                 "unittitle": {
@@ -28912,7 +29200,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1959-1965",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1959/1965"
                                     }
                                 ],
                                 "unittitle": {
@@ -29171,7 +29460,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1998",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1998/1998"
                                     }
                                 ],
                                 "unittitle": {
@@ -29329,7 +29619,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1987",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1987/1987"
                                     }
                                 ],
                                 "unittitle": {
@@ -29509,7 +29800,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1869-1938",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1869/1938"
                                     }
                                 ],
                                 "unittitle": {
@@ -30532,7 +30824,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1869-1955",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1869/1955"
                                     }
                                 ],
                                 "unittitle": {
@@ -30775,7 +31068,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1906-1966",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1906/1966"
                                     }
                                 ],
                                 "unittitle": {
@@ -30880,7 +31174,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1869-1945",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1869/1945"
                                     }
                                 ],
                                 "unittitle": {
@@ -30995,7 +31290,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1884-1933",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1884/1933"
                                             }
                                         ],
                                         "unittitle": {
@@ -31018,7 +31314,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1888-1927",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1888/1927"
                                             }
                                         ],
                                         "unittitle": {
@@ -31041,7 +31338,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1906-1932",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1906/1932"
                                             }
                                         ],
                                         "unittitle": {
@@ -31064,7 +31362,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1912-1944",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1912/1944"
                                             }
                                         ],
                                         "unittitle": {
@@ -31241,7 +31540,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1927-1957",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1927/1957"
                                             }
                                         ],
                                         "unittitle": {
@@ -31313,7 +31613,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1874-1879",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1874/1879"
                                             }
                                         ],
                                         "unittitle": {
@@ -31336,7 +31637,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1880-1885",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1880/1885"
                                             }
                                         ],
                                         "unittitle": {
@@ -31359,7 +31661,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1885-1889",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1885/1889"
                                             }
                                         ],
                                         "unittitle": {
@@ -31382,7 +31685,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1889-1893",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1889/1893"
                                             }
                                         ],
                                         "unittitle": {
@@ -31405,7 +31709,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1893-1899",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1893/1899"
                                             }
                                         ],
                                         "unittitle": {
@@ -31428,7 +31733,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1899-1904",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1899/1904"
                                             }
                                         ],
                                         "unittitle": {
@@ -31451,7 +31757,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1904-1909",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1904/1909"
                                             }
                                         ],
                                         "unittitle": {
@@ -31474,7 +31781,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1909-1911",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1909/1911"
                                             }
                                         ],
                                         "unittitle": {
@@ -31497,7 +31805,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1912-1914",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1912/1914"
                                             }
                                         ],
                                         "unittitle": {
@@ -31520,7 +31829,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1915-1916",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1915/1916"
                                             }
                                         ],
                                         "unittitle": {
@@ -31543,7 +31853,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1917-1918",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1917/1918"
                                             }
                                         ],
                                         "unittitle": {
@@ -31566,7 +31877,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1919-1920",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1919/1920"
                                             }
                                         ],
                                         "unittitle": {
@@ -31589,7 +31901,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1921-1922",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1921/1922"
                                             }
                                         ],
                                         "unittitle": {
@@ -31612,7 +31925,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1923-1924",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1923/1924"
                                             }
                                         ],
                                         "unittitle": {
@@ -31635,7 +31949,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1925-1926",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1925/1926"
                                             }
                                         ],
                                         "unittitle": {
@@ -31658,7 +31973,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1927-1929",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1927/1929"
                                             }
                                         ],
                                         "unittitle": {
@@ -31681,7 +31997,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1929",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1929/1929"
                                             }
                                         ],
                                         "unittitle": {
@@ -31704,7 +32021,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1930",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1930/1930"
                                             }
                                         ],
                                         "unittitle": {
@@ -31754,7 +32072,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1912-1924",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1912/1924"
                                             }
                                         ],
                                         "unittitle": {
@@ -31777,7 +32096,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1925-1928",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1925/1928"
                                             }
                                         ],
                                         "unittitle": {
@@ -31800,7 +32120,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1924-1927",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1924/1927"
                                             }
                                         ],
                                         "unittitle": {
@@ -31823,7 +32144,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1935-1955",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1935/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -31873,7 +32195,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1872-1893",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1872/1893"
                                             }
                                         ],
                                         "unittitle": {
@@ -31896,7 +32219,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "1875-1928",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "1875/1928"
                                             }
                                         ],
                                         "unittitle": {
@@ -34279,7 +34603,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1992-1997",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1992/1997"
                                     }
                                 ],
                                 "unittitle": {
@@ -34302,7 +34627,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1958-2005",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1958/2005"
                                     }
                                 ],
                                 "unittitle": {
@@ -34501,7 +34827,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1988-2003",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1988/2003"
                                     }
                                 ],
                                 "unittitle": {
@@ -34640,7 +34967,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1951",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1951/1951"
                                     }
                                 ],
                                 "unittitle": {
@@ -34663,7 +34991,8 @@
                                 "unitdate": [
                                     {
                                         "value": "2001",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "2001/2001"
                                     }
                                 ],
                                 "unittitle": {
@@ -34686,7 +35015,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1972",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1972/1972"
                                     }
                                 ],
                                 "unittitle": {
@@ -34709,7 +35039,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1999",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1999/1999"
                                     }
                                 ],
                                 "unittitle": {
@@ -34732,7 +35063,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1999",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1999/1999"
                                     }
                                 ],
                                 "unittitle": {
@@ -34755,7 +35087,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1992",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1992/1992"
                                     }
                                 ],
                                 "unittitle": {
@@ -34778,7 +35111,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1993",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1993/1993"
                                     }
                                 ],
                                 "unittitle": {
@@ -34801,7 +35135,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1997",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1997/1997"
                                     }
                                 ],
                                 "unittitle": {
@@ -34824,7 +35159,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1997",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1997/1997"
                                     }
                                 ],
                                 "unittitle": {
@@ -34847,7 +35183,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1997",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1997/1997"
                                     }
                                 ],
                                 "unittitle": {
@@ -34870,7 +35207,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1997",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1997/1997"
                                     }
                                 ],
                                 "unittitle": {
@@ -34893,7 +35231,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1990",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1990/1990"
                                     }
                                 ],
                                 "unittitle": {
@@ -34916,7 +35255,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1965",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "1965/1965"
                                     }
                                 ],
                                 "unittitle": {

--- a/ead/testdata/nyuad/ad_mc_019-edited.json
+++ b/ead/testdata/nyuad/ad_mc_019-edited.json
@@ -70,7 +70,8 @@
                 {
                     "value": "1561-2003",
                     "type": "inclusive",
-                    "datechar": "creation"
+                    "datechar": "creation",
+                    "normal": "1561/2003"
                 }
             ],
             "unitid": "AD.MC.019",
@@ -120,7 +121,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1856",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1856/1856"
                                     }
                                 ],
                                 "unittitle": {
@@ -194,7 +196,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1855",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1855/1855"
                                     }
                                 ],
                                 "unittitle": {
@@ -238,7 +241,8 @@
                             {
                                 "value": "1855-1856",
                                 "type": "inclusive",
-                                "datechar": "creation"
+                                "datechar": "creation",
+                                "normal": "1855/1856"
                             }
                         ],
                         "unittitle": {
@@ -271,7 +275,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1968",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1968/1968"
                                     }
                                 ],
                                 "unittitle": {
@@ -328,7 +333,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1945",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1945/1945"
                                     }
                                 ],
                                 "unittitle": {
@@ -424,7 +430,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1939",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1939/1939"
                                     }
                                 ],
                                 "unittitle": {
@@ -469,7 +476,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1973",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1973/1973"
                                     }
                                 ],
                                 "unittitle": {
@@ -528,7 +536,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1993",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1993/1993"
                                     }
                                 ],
                                 "unittitle": {
@@ -585,7 +594,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1947",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1947/1947"
                                     }
                                 ],
                                 "unittitle": {
@@ -644,7 +654,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1950",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1950/1950"
                                     }
                                 ],
                                 "unittitle": {
@@ -683,7 +694,8 @@
                             {
                                 "value": "1939-1993",
                                 "type": "inclusive",
-                                "datechar": "creation"
+                                "datechar": "creation",
+                                "normal": "1939/1993"
                             }
                         ],
                         "unittitle": {
@@ -747,7 +759,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1925",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1925/1925"
                                     }
                                 ],
                                 "unittitle": {
@@ -821,7 +834,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1561",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1561/1561"
                                     }
                                 ],
                                 "unittitle": {
@@ -895,7 +909,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1614",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1614/1614"
                                     }
                                 ],
                                 "unittitle": {
@@ -952,7 +967,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1925",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1925/1925"
                                     }
                                 ],
                                 "unittitle": {
@@ -1025,7 +1041,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1872",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1872/1872"
                                     }
                                 ],
                                 "unittitle": {
@@ -1082,7 +1099,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1654",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1654/1654"
                                     }
                                 ],
                                 "unittitle": {
@@ -1125,7 +1143,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1907",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1907/1907"
                                     }
                                 ],
                                 "unittitle": {
@@ -1184,7 +1203,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1821",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1821/1821"
                                     }
                                 ],
                                 "unittitle": {
@@ -1229,7 +1249,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1960",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1960/1960"
                                     }
                                 ],
                                 "unittitle": {
@@ -1258,7 +1279,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1977",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1977/1977"
                                     }
                                 ],
                                 "unittitle": {
@@ -1287,7 +1309,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1977",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1977/1977"
                                     }
                                 ],
                                 "unittitle": {
@@ -1316,7 +1339,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1977",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1977/1977"
                                     }
                                 ],
                                 "unittitle": {
@@ -1345,7 +1369,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1977",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1977/1977"
                                     }
                                 ],
                                 "unittitle": {
@@ -1374,7 +1399,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1977",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1977/1977"
                                     }
                                 ],
                                 "unittitle": {
@@ -1403,7 +1429,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1977",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1977/1977"
                                     }
                                 ],
                                 "unittitle": {
@@ -1432,7 +1459,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1977",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1977/1977"
                                     }
                                 ],
                                 "unittitle": {
@@ -1461,7 +1489,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1977",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1977/1977"
                                     }
                                 ],
                                 "unittitle": {
@@ -1475,7 +1504,8 @@
                             {
                                 "value": "1561-1977",
                                 "type": "inclusive",
-                                "datechar": "creation"
+                                "datechar": "creation",
+                                "normal": "1561/1977"
                             }
                         ],
                         "unittitle": {
@@ -1506,7 +1536,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1861",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1861/1861"
                                     }
                                 ],
                                 "unittitle": {
@@ -1549,7 +1580,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1925",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1925/1925"
                                     }
                                 ],
                                 "unittitle": {
@@ -1609,7 +1641,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1601",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1601/1601"
                                     }
                                 ],
                                 "unittitle": {
@@ -1666,7 +1699,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1878",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1878/1878"
                                     }
                                 ],
                                 "unittitle": {
@@ -1696,7 +1730,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1956",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1956/1956"
                                     }
                                 ],
                                 "unittitle": {
@@ -1753,7 +1788,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1624 [?]",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1624/1624"
                                     }
                                 ],
                                 "unittitle": {
@@ -1824,7 +1860,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1776",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1776/1776"
                                     }
                                 ],
                                 "unittitle": {
@@ -1869,7 +1906,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1776",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1776/1776"
                                     }
                                 ],
                                 "unittitle": {
@@ -1943,7 +1981,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1598",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1598/1598"
                                     }
                                 ],
                                 "unittitle": {
@@ -2016,7 +2055,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1922",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1922/1922"
                                     }
                                 ],
                                 "unittitle": {
@@ -2092,7 +2132,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1662 (?)",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1662/1662"
                                     }
                                 ],
                                 "unittitle": {
@@ -2136,7 +2177,8 @@
                             {
                                 "value": "1598-1956",
                                 "type": "inclusive",
-                                "datechar": "creation"
+                                "datechar": "creation",
+                                "normal": "1598/1956"
                             }
                         ],
                         "unittitle": {
@@ -2184,7 +2226,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1835",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1835/1835"
                                     }
                                 ],
                                 "unittitle": {
@@ -2258,7 +2301,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1855",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1855/1855"
                                     }
                                 ],
                                 "unittitle": {
@@ -2317,7 +2361,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1593",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1593/1593"
                                     }
                                 ],
                                 "unittitle": {
@@ -2391,7 +2436,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1701",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1701/1701"
                                     }
                                 ],
                                 "unittitle": {
@@ -2462,7 +2508,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1918",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1918/1918"
                                     }
                                 ],
                                 "unittitle": {
@@ -2519,7 +2566,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1918",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1918/1918"
                                     }
                                 ],
                                 "unittitle": {
@@ -2576,7 +2624,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1917",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1917/1917"
                                     }
                                 ],
                                 "unittitle": {
@@ -2621,7 +2670,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1723",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1723/1723"
                                     }
                                 ],
                                 "unittitle": {
@@ -2696,7 +2746,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1626",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1626/1626"
                                     }
                                 ],
                                 "unittitle": {
@@ -2770,7 +2821,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1702",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1702/1702"
                                     }
                                 ],
                                 "unittitle": {
@@ -2844,7 +2896,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1686?",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1686/1686"
                                     }
                                 ],
                                 "unittitle": {
@@ -2888,7 +2941,8 @@
                             {
                                 "value": "1593-1918",
                                 "type": "inclusive",
-                                "datechar": "creation"
+                                "datechar": "creation",
+                                "normal": "1593/1918"
                             }
                         ],
                         "unittitle": {
@@ -2936,7 +2990,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1779",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1779/1779"
                                     }
                                 ],
                                 "unittitle": {
@@ -3010,7 +3065,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1634",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1634/1634"
                                     }
                                 ],
                                 "unittitle": {
@@ -3084,7 +3140,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1782",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1782/1782"
                                     }
                                 ],
                                 "unittitle": {
@@ -3158,7 +3215,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1613",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1613/1613"
                                     }
                                 ],
                                 "unittitle": {
@@ -3229,7 +3287,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1974",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1974/1974"
                                     }
                                 ],
                                 "unittitle": {
@@ -3295,7 +3354,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1740?",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1740/1740"
                                     }
                                 ],
                                 "unittitle": {
@@ -3366,7 +3426,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1626",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1626/1626"
                                     }
                                 ],
                                 "unittitle": {
@@ -3410,7 +3471,8 @@
                             {
                                 "value": "1613-1974",
                                 "type": "inclusive",
-                                "datechar": "creation"
+                                "datechar": "creation",
+                                "normal": "1613/1974"
                             }
                         ],
                         "unittitle": {
@@ -3458,7 +3520,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1740",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1740/1740"
                                     }
                                 ],
                                 "unittitle": {
@@ -3532,7 +3595,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1817",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1817/1817"
                                     }
                                 ],
                                 "unittitle": {
@@ -3576,7 +3640,8 @@
                             {
                                 "value": "1740-1817",
                                 "type": "inclusive",
-                                "datechar": "creation"
+                                "datechar": "creation",
+                                "normal": "1740/1817"
                             }
                         ],
                         "unittitle": {
@@ -3609,7 +3674,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1994/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -3638,7 +3704,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1994/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -3667,7 +3734,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1994/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -3696,7 +3764,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1994/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -3725,7 +3794,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1994/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -3754,7 +3824,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1994/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -3783,7 +3854,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1994/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -3812,7 +3884,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1994/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -3841,7 +3914,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1994/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -3870,7 +3944,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1994/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -3899,7 +3974,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1994/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -3928,7 +4004,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1994/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -3957,7 +4034,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1994/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -3986,7 +4064,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1994",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1994/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -4015,7 +4094,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1995",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1995/1995"
                                     }
                                 ],
                                 "unittitle": {
@@ -4044,7 +4124,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1995",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1995/1995"
                                     }
                                 ],
                                 "unittitle": {
@@ -4073,7 +4154,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1996",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1996/1996"
                                     }
                                 ],
                                 "unittitle": {
@@ -4102,7 +4184,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1997",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1997/1997"
                                     }
                                 ],
                                 "unittitle": {
@@ -4131,7 +4214,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1998",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1998/1998"
                                     }
                                 ],
                                 "unittitle": {
@@ -4160,7 +4244,8 @@
                                 "unitdate": [
                                     {
                                         "value": "2000",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "2000/2000"
                                     }
                                 ],
                                 "unittitle": {
@@ -4190,7 +4275,8 @@
                                     {
                                         "value": "2001-2003",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "2001/2003"
                                     }
                                 ],
                                 "unittitle": {
@@ -4204,7 +4290,8 @@
                             {
                                 "value": "1994-2003",
                                 "type": "inclusive",
-                                "datechar": "creation"
+                                "datechar": "creation",
+                                "normal": "1994/2003"
                             }
                         ],
                         "unittitle": {
@@ -4267,7 +4354,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1751",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1751/1751"
                                     }
                                 ],
                                 "unittitle": {
@@ -4341,7 +4429,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1835",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1835/1835"
                                     }
                                 ],
                                 "unittitle": {
@@ -4415,7 +4504,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1719",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1719/1719"
                                     }
                                 ],
                                 "unittitle": {
@@ -4489,7 +4579,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1856",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1856/1856"
                                     }
                                 ],
                                 "unittitle": {
@@ -4563,7 +4654,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1795",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1795/1795"
                                     }
                                 ],
                                 "unittitle": {
@@ -4622,7 +4714,8 @@
                                 "unitdate": [
                                     {
                                         "value": "circa 1820",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1820/1820"
                                     }
                                 ],
                                 "unittitle": {
@@ -4682,7 +4775,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1877",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1877/1877"
                                     }
                                 ],
                                 "unittitle": {
@@ -4713,7 +4807,8 @@
                                 "unitdate": [
                                     {
                                         "value": "1937",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1937/1937"
                                     }
                                 ],
                                 "unittitle": {
@@ -4743,7 +4838,8 @@
                             {
                                 "value": "1719-1937",
                                 "type": "inclusive",
-                                "datechar": "creation"
+                                "datechar": "creation",
+                                "normal": "1719/1937"
                             }
                         ],
                         "unittitle": {

--- a/ead/testdata/omega/v0.1.5/mos_2021-with-donors-with-image-counts.json
+++ b/ead/testdata/omega/v0.1.5/mos_2021-with-donors-with-image-counts.json
@@ -465,11 +465,13 @@
             "unitdate": [
                 {
                     "value": "2016-2021, undated",
-                    "type": "inclusive"
+                    "type": "inclusive",
+                    "normal": "2016/2021"
                 },
                 {
                     "value": "2020-2021, undated",
-                    "type": "bulk"
+                    "type": "bulk",
+                    "normal": "2020/2021"
                 }
             ],
             "unitid": "MOS.2021",
@@ -985,7 +987,8 @@
                                                             "did": {
                                                                 "unitdate": [
                                                                     {
-                                                                        "value": "1981-08-31"
+                                                                        "value": "1981-08-31",
+                                                                        "normal": "1981-08-31/1981-08-31"
                                                                     }
                                                                 ],
                                                                 "unittitle": {
@@ -1214,7 +1217,8 @@
                                                         "unitdate": [
                                                             {
                                                                 "value": "2020",
-                                                                "type": "inclusive"
+                                                                "type": "inclusive",
+                                                                "normal": "2020/2020"
                                                             }
                                                         ],
                                                         "unitid": "mos_2021_6",
@@ -1879,7 +1883,8 @@
                                                 "unitdate": [
                                                     {
                                                         "value": "2015-2019",
-                                                        "type": "inclusive"
+                                                        "type": "inclusive",
+                                                        "normal": "2015/2019"
                                                     }
                                                 ],
                                                 "unitid": "mos_2021_5",
@@ -2544,7 +2549,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "2017-2019",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "2017/2019"
                                             }
                                         ],
                                         "unitid": "mos_2021_4",
@@ -3204,7 +3210,8 @@
                                 "unitdate": [
                                     {
                                         "value": "2021",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "2021/2021"
                                     }
                                 ],
                                 "unitid": "mos_2021_3",
@@ -3792,7 +3799,8 @@
                                 ],
                                 "unitdate": [
                                     {
-                                        "value": "1981-09-02"
+                                        "value": "1981-09-02",
+                                        "normal": "1981-09-02/1981-09-02"
                                     }
                                 ],
                                 "unittitle": {
@@ -4013,7 +4021,8 @@
                         "unitdate": [
                             {
                                 "value": "2015-2016",
-                                "type": "inclusive"
+                                "type": "inclusive",
+                                "normal": "2015/2016"
                             }
                         ],
                         "unitid": "mos_2021_2",

--- a/ead/testdata/omega/v0.1.5/mos_2021-with-donors.json
+++ b/ead/testdata/omega/v0.1.5/mos_2021-with-donors.json
@@ -465,11 +465,13 @@
             "unitdate": [
                 {
                     "value": "2016-2021, undated",
-                    "type": "inclusive"
+                    "type": "inclusive",
+                    "normal": "2016/2021"
                 },
                 {
                     "value": "2020-2021, undated",
-                    "type": "bulk"
+                    "type": "bulk",
+                    "normal": "2020/2021"
                 }
             ],
             "unitid": "MOS.2021",
@@ -985,7 +987,8 @@
                                                             "did": {
                                                                 "unitdate": [
                                                                     {
-                                                                        "value": "1981-08-31"
+                                                                        "value": "1981-08-31",
+                                                                        "normal": "1981-08-31/1981-08-31"
                                                                     }
                                                                 ],
                                                                 "unittitle": {
@@ -1214,7 +1217,8 @@
                                                         "unitdate": [
                                                             {
                                                                 "value": "2020",
-                                                                "type": "inclusive"
+                                                                "type": "inclusive",
+                                                                "normal": "2020/2020"
                                                             }
                                                         ],
                                                         "unitid": "mos_2021_6",
@@ -1877,7 +1881,8 @@
                                                 "unitdate": [
                                                     {
                                                         "value": "2015-2019",
-                                                        "type": "inclusive"
+                                                        "type": "inclusive",
+                                                        "normal": "2015/2019"
                                                     }
                                                 ],
                                                 "unitid": "mos_2021_5",
@@ -2540,7 +2545,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "2017-2019",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "2017/2019"
                                             }
                                         ],
                                         "unitid": "mos_2021_4",
@@ -3200,7 +3206,8 @@
                                 "unitdate": [
                                     {
                                         "value": "2021",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "2021/2021"
                                     }
                                 ],
                                 "unitid": "mos_2021_3",
@@ -3788,7 +3795,8 @@
                                 ],
                                 "unitdate": [
                                     {
-                                        "value": "1981-09-02"
+                                        "value": "1981-09-02",
+                                        "normal": "1981-09-02/1981-09-02"
                                     }
                                 ],
                                 "unittitle": {
@@ -4009,7 +4017,8 @@
                         "unitdate": [
                             {
                                 "value": "2015-2016",
-                                "type": "inclusive"
+                                "type": "inclusive",
+                                "normal": "2015/2016"
                             }
                         ],
                         "unitid": "mos_2021_2",

--- a/ead/testdata/omega/v0.1.5/mos_2021-with-presentation-elements-in-titlestmt-children.json
+++ b/ead/testdata/omega/v0.1.5/mos_2021-with-presentation-elements-in-titlestmt-children.json
@@ -459,11 +459,13 @@
             "unitdate": [
                 {
                     "value": "2016-2021, undated",
-                    "type": "inclusive"
+                    "type": "inclusive",
+                    "normal": "2016/2021"
                 },
                 {
                     "value": "2020-2021, undated",
-                    "type": "bulk"
+                    "type": "bulk",
+                    "normal": "2020/2021"
                 }
             ],
             "unitid": "MOS.2021",
@@ -979,7 +981,8 @@
                                                             "did": {
                                                                 "unitdate": [
                                                                     {
-                                                                        "value": "1981-08-31"
+                                                                        "value": "1981-08-31",
+                                                                        "normal": "1981-08-31/1981-08-31"
                                                                     }
                                                                 ],
                                                                 "unittitle": {
@@ -1208,7 +1211,8 @@
                                                         "unitdate": [
                                                             {
                                                                 "value": "2020",
-                                                                "type": "inclusive"
+                                                                "type": "inclusive",
+                                                                "normal": "2020/2020"
                                                             }
                                                         ],
                                                         "unitid": "mos_2021_6",
@@ -1871,7 +1875,8 @@
                                                 "unitdate": [
                                                     {
                                                         "value": "2015-2019",
-                                                        "type": "inclusive"
+                                                        "type": "inclusive",
+                                                        "normal": "2015/2019"
                                                     }
                                                 ],
                                                 "unitid": "mos_2021_5",
@@ -2534,7 +2539,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "2017-2019",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "2017/2019"
                                             }
                                         ],
                                         "unitid": "mos_2021_4",
@@ -3194,7 +3200,8 @@
                                 "unitdate": [
                                     {
                                         "value": "2021",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "2021/2021"
                                     }
                                 ],
                                 "unitid": "mos_2021_3",
@@ -3782,7 +3789,8 @@
                                 ],
                                 "unitdate": [
                                     {
-                                        "value": "1981-09-02"
+                                        "value": "1981-09-02",
+                                        "normal": "1981-09-02/1981-09-02"
                                     }
                                 ],
                                 "unittitle": {
@@ -4003,7 +4011,8 @@
                         "unitdate": [
                             {
                                 "value": "2015-2016",
-                                "type": "inclusive"
+                                "type": "inclusive",
+                                "normal": "2015/2016"
                             }
                         ],
                         "unitid": "mos_2021_2",

--- a/ead/testdata/omega/v0.1.5/mos_2021.json
+++ b/ead/testdata/omega/v0.1.5/mos_2021.json
@@ -459,11 +459,13 @@
             "unitdate": [
                 {
                     "value": "2016-2021, undated",
-                    "type": "inclusive"
+                    "type": "inclusive",
+                    "normal": "2016/2021"
                 },
                 {
                     "value": "2020-2021, undated",
-                    "type": "bulk"
+                    "type": "bulk",
+                    "normal": "2020/2021"
                 }
             ],
             "unitid": "MOS.2021",
@@ -979,7 +981,8 @@
                                                             "did": {
                                                                 "unitdate": [
                                                                     {
-                                                                        "value": "1981-08-31"
+                                                                        "value": "1981-08-31",
+                                                                        "normal": "1981-08-31/1981-08-31"
                                                                     }
                                                                 ],
                                                                 "unittitle": {
@@ -1208,7 +1211,8 @@
                                                         "unitdate": [
                                                             {
                                                                 "value": "2020",
-                                                                "type": "inclusive"
+                                                                "type": "inclusive",
+                                                                "normal": "2020/2020"
                                                             }
                                                         ],
                                                         "unitid": "mos_2021_6",
@@ -1871,7 +1875,8 @@
                                                 "unitdate": [
                                                     {
                                                         "value": "2015-2019",
-                                                        "type": "inclusive"
+                                                        "type": "inclusive",
+                                                        "normal": "2015/2019"
                                                     }
                                                 ],
                                                 "unitid": "mos_2021_5",
@@ -2534,7 +2539,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "2017-2019",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "2017/2019"
                                             }
                                         ],
                                         "unitid": "mos_2021_4",
@@ -3194,7 +3200,8 @@
                                 "unitdate": [
                                     {
                                         "value": "2021",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "2021/2021"
                                     }
                                 ],
                                 "unitid": "mos_2021_3",
@@ -3782,7 +3789,8 @@
                                 ],
                                 "unitdate": [
                                     {
-                                        "value": "1981-09-02"
+                                        "value": "1981-09-02",
+                                        "normal": "1981-09-02/1981-09-02"
                                     }
                                 ],
                                 "unittitle": {
@@ -4003,7 +4011,8 @@
                         "unitdate": [
                             {
                                 "value": "2015-2016",
-                                "type": "inclusive"
+                                "type": "inclusive",
+                                "normal": "2015/2016"
                             }
                         ],
                         "unitid": "mos_2021_2",

--- a/ead/testdata/tamwag/mos_2021-with-test-unitdates.xml
+++ b/ead/testdata/tamwag/mos_2021-with-test-unitdates.xml
@@ -1,0 +1,1614 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ead xmlns="urn:isbn:1-931666-22-9" xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd">
+  <eadheader countryencoding="iso3166-1" dateencoding="iso8601" findaidstatus="completed"
+    langencoding="iso639-2b" repositoryencoding="iso15511">
+    <eadid url="http://dlib.nyu.edu/findingaids/html/tamwag/mos_2021">mos_2021</eadid>
+    <filedesc>
+      <titlestmt>
+        <titleproper type="filing">This is the Finding Aid Filing Title</titleproper>
+        <titleproper>Guide to Megan O'Shea's <emph render="italic">One</emph> Resource to <lb/> Rule
+          Them All <num>MOS.2021</num></titleproper>
+        <subtitle>A Wicked Awesome Resource Record</subtitle>
+        <author>Megan O'Shea</author>
+        <sponsor>Creation of this finding aid funded by New York University Libraries.</sponsor>
+      </titlestmt>
+      <editionstmt>
+        <p>First edition</p>
+      </editionstmt>
+      <publicationstmt>
+        <publisher>Tamiment Library and Robert F. Wagner Labor Archives</publisher>
+        <p><date>March 2023</date></p>
+        <address>
+          <addressline>Elmer Holmes Bobst Library</addressline>
+          <addressline>70 Washington Square South</addressline>
+          <addressline>2nd Floor</addressline>
+          <addressline>New York, NY 10012</addressline>
+          <addressline>special.collections@nyu.edu</addressline>
+          <addressline>URL: <extptr
+              xlink:href="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+              xlink:show="new"
+              xlink:title="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+              xlink:type="simple"/></addressline>
+        </address>
+      </publicationstmt>
+      <notestmt>
+        <note>
+          <p>Here is a note.</p>
+        </note>
+      </notestmt>
+    </filedesc>
+    <profiledesc>
+      <creation>This finding aid was produced using ArchivesSpace and manual edits on
+          <date>2023-03-23 13:50:52 -0400</date>.</creation>
+      <langusage>Finding aid written in <language langcode="eng" encodinganalog="546"
+          >English</language>.</langusage>
+      <descrules>Describing Archives: A Content Standard</descrules>
+    </profiledesc>
+    <revisiondesc>
+      <change>
+        <date>March 2021</date>
+        <item>Updated by Megan O'Shea in order to include this note</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <archdesc level="collection">
+    <did>
+      <repository>
+        <corpname>Tamiment Library and Robert F. Wagner Labor Archives</corpname>
+      </repository>
+      <unittitle>Megan O'Shea's One Resource to Rule Them All</unittitle>
+      <origination label="Creator">
+        <persname role="dnr" rules="local" source="local"> Megan O'Shea</persname>
+      </origination>
+      <origination label="source">
+        <persname role="dnr" source="naf">Debs, Eugene V. (Eugene Victor), 1855-1926</persname>
+      </origination>
+      <origination label="Creator">
+        <famname role="dnr" rules="dacs" source="local">Belfrage family</famname>
+      </origination>
+      <origination label="source">
+        <corpname role="dnr" source="naf">Tamiment Library</corpname>
+      </origination>
+      <origination label="Creator">
+        <persname rules="local" source="local"> Weatherly Stephan</persname>
+      </origination>
+      <unitid>MOS.2021</unitid>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">25 Linear Feet</extent>
+        <extent altrender="carrier">in <emph render="bold">24 record cartons</emph>, <lb/>1
+          manuscript box, and 1 flat file folder</extent>
+        <dimensions><dimensions id="aspace_2234224" label="dimensions">24" x
+          24"</dimensions></dimensions>
+      </physdesc>
+      <!-- begin test unit dates -->
+      <!--
+        test cases:
+        unitdate element has a value                       ====> value is used in JSON
+        unitdate element is empty but @normal is populated ====> @normal is used, per conversion rules
+        unitdate element is empty AND @normal is empty     ====> omit element 
+        
+        @normal conversion rules:
+        normal="date_A/date_B" ====> date_A-date_B
+        normal="date_A/date_A" ====> date_A
+        
+        -->
+      <unitdate normal="2016/2021" type="inclusive">2016-2021, undated</unitdate>
+      <unitdate normal="1910/1910" type="inclusive">circa 1910</unitdate>
+      <unitdate normal="1977/2000" type="inclusive"/>
+      <unitdate datechar="digitized" normal="2013/2013"> </unitdate>
+      <unitdate datechar="digitized"> </unitdate>
+      <unitdate datechar="digitized" normal="1914/2014"> </unitdate>
+      <unitdate datechar="digitized" normal="2018-02-08/2018-02-08"> </unitdate>
+      <abstract id="aspace_ref3">This is the <emph render="italic">abstract</emph>.<lb/> It has a
+          <title>title</title> in it.</abstract>
+      <physdesc>
+        <physfacet id="aspace_22323" label="Physical Facets Are Important">This is the <emph
+            render="italic">physical facet</emph> of the collection.</physfacet>
+      </physdesc>
+      <physdesc id="aspace_29d371fa27aa7ebbde64468e06791bbc"><extent unit="folders"
+        >10</extent></physdesc>
+      <langmaterial id="aspace_791d685c5b2d2cc8c7d9d982ed6d5dee"><emph>English is the
+          language</emph></langmaterial>
+    </did>
+    <accessrestrict id="aspace_7737a7dc7fd92d0055945aaca8066375">
+      <head>Conditions Governing Access</head>
+      <legalstatus id="whatever">This is the Conditions Governing Access note.</legalstatus>
+
+      <p><chronlist>
+          <head>The following chronology provides a backdrop for the Board of Higher Education of
+            the City of New York cases included within this collection:</head>
+          <chronitem>
+            <date>1939</date>
+            <eventgrp>
+              <event>The <emph render="italic">New York State Legislature</emph> enacted Section
+                12-a of the <title>Civil Service Law</title> which provided in substance that "no
+                person shall be appointed to or retained in the public service nor in any public
+                educational institution who becomes a member of any organization which advocates the
+                overthrow of government by force or violence, or by any unlawful means (L. 1939, Ch.
+                547)."</event>
+            </eventgrp>
+          </chronitem>
+        </chronlist></p>
+
+      <p><list type="deflist">
+          <listhead>
+            <head01>Abbreviation</head01>
+            <head02>Expansion</head02>
+          </listhead>
+          <defitem>
+            <label>MIT</label>
+            <item>Massachusetts Institute of Technology</item>
+          </defitem>
+          <defitem>
+            <label>PCV</label>
+            <item>Peace Corps Volunteer</item>
+          </defitem>
+        </list></p>
+      <list numeration="arabic" type="ordered">
+        <head>Ordered List</head>
+        <item><bibref>This is a citation for <persname>Weatherly Stephan</persname>'s <title>Journal
+              of Archival Organization</title> article.</bibref></item>
+        <item>I don't know why on earth you'd put a <emph render="bold">line break</emph> in an
+          ordered list, <lb/> but here ya go.</item>
+        <item>Copyright <corpname>New York University</corpname>, all rights reserved.</item>
+        <item>This is just a <name>name</name> name with no identity.</item>
+      </list>
+    </accessrestrict>
+    <accruals id="aspace_f05011cc547339bd4114711751029c6d">
+      <head>Accruals <emph render="bold">Note</emph></head>
+      <p>This is the Accruals note.</p>
+    </accruals>
+    <acqinfo id="aspace_7be31470c64f6cfbf4336ba9af1a31d3">
+      <head>Immediate Source of Acquisition</head>
+      <p>This is the Immediate Source of Acquisition note.</p>
+    </acqinfo>
+    <appraisal id="aspace_45cf36d965d0f038d67621dbebb9ebf1">
+      <head>Appraisal</head>
+      <p>This is the Appraisal note.</p>
+    </appraisal>
+    <arrangement id="aspace_65d23a620677d7f70a9b3dcfa9523829">
+      <head>Arrangement</head>
+      <p>This is the Arrangement note.</p>
+    </arrangement>
+    <bioghist id="aspace_5bfa9f2060a4b600e0b0ae6c3924354b">
+      <head>Biographical Note</head>
+      <p>This is the Biographical note.</p>
+    </bioghist>
+    <custodhist id="aspace_03c962dea0c06463b3615c01bc8ac97e">
+      <head>Custodial History</head>
+      <p>This is the Custodial History note.</p>
+    </custodhist>
+    <odd id="aspace_0c2299264bc16498d16857b8d48c6626">
+      <head>General</head>
+      <p>This is the General note. <address>
+          <addressline>Elmer Holmes Bobst Library</addressline>
+          <addressline>70 Washington Square South</addressline>
+          <addressline>2nd Floor</addressline>
+          <addressline>New York, NY 10012</addressline>
+          <addressline>special.collections@nyu.edu</addressline>
+          <addressline>URL: <extptr
+              xlink:href="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+              xlink:show="new"
+              xlink:title="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+              xlink:type="simple"/></addressline>
+        </address>
+        <abbr expan="Autographed Letter Signed">ALS</abbr>
+        <archref>
+          <extref xlink:href="http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/"
+            xlink:title="Sally Belfrage" xlink:type="simple" xlink:show="new">The Sally Belfrage
+            Papers (TAM 189)</extref></archref>
+        <bibref><emph render="bold">Ardouin, Charles Nicholas Celigny</emph>. <title render="italic"
+            >Essais sur l'histoire d'Haiti</title>. Port-au-Prince, 1865.</bibref>
+        <blockquote>
+          <p>No doubt the estate has exerted a tremendous influence on the development of my
+            character. One may walk for an hour without glimpsing another soul, which has taught me
+            to love tranquility.</p>
+        </blockquote><lb/>
+        <corpname source="naf">Tamiment Library</corpname>
+        <date>March 2021</date>
+        <list type="deflist" numeration="arabic">
+          <listhead>
+            <head01>Abbreviation</head01>
+            <head02>Expansion</head02>
+          </listhead>
+          <defitem>
+            <label>MIT</label>
+            <item>Massachusetts Institute of Technology</item>
+          </defitem>
+        </list>
+        <genreform source="aat">Oral histories (literary works)</genreform>
+        <name>Rolodex</name>
+        <num type="collection">MOS.2021</num>
+        <occupation source="lcsh">Fulbright scholars.</occupation>
+        <subject source="lcsh">Irish American women -- History -- 19th century.</subject>
+      </p>
+    </odd>
+    <originalsloc id="aspace_aa0a0cdc1b60f061cdbae4abf56bcfb7">
+      <head>Existence and Location of Originals</head>
+      <p>This is the Existence and Location of Originals note.</p>
+    </originalsloc>
+    <otherfindaid id="aspace_0b719130b0efb4b3dd232a74de098aa9">
+      <head>Other Finding Aids</head>
+      <p>This is the Other Finding Aids note.</p>
+    </otherfindaid>
+    <phystech id="aspace_6535a00a00c94c0593f378d76d4dec87">
+      <head>Physical Characteristics and Technical Requirements</head>
+      <p>This is the Physical Characteristics and Technical Requirements note.</p>
+    </phystech>
+    <prefercite id="aspace_3a758dcc0a9eafb7976839a96615fa21">
+      <head>Preferred Citation</head>
+      <p>This is the Preferred Citation note.</p>
+    </prefercite>
+    <processinfo id="aspace_ede025697b8e5bd48a2e9752bb4eb634">
+      <head>Processing Information</head>
+      <p>This is the Processing Information note.</p>
+    </processinfo>
+    <relatedmaterial id="aspace_5234804138e0f9a3a4639042d816b7f4">
+      <head>Related Materials</head>
+      <p>This is the Related Materials note. Those using the collection may also be interested in
+        P132, held in this repository, which includes photographs of Pemberly, Darcy's estate and
+        childhood home. In an April 1795 letter to his friend, Charles Bingley, Darcy wrote <blockquote>
+          <p>No doubt the estate has exerted a tremendous influence on the development of my
+            character. One may walk for an hour without glimpsing another soul, which has taught me
+            to love tranquility.</p>
+        </blockquote>
+        <archref>
+          <extref xlink:href="http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/">The Sally
+            Belfrage Papers (TAM 189)</extref></archref></p>
+    </relatedmaterial>
+    <scopecontent id="aspace_c2e115638fa0f6448f8a05f567287451">
+      <head>Scope and Content</head>
+      <p>This is the Scope and Content note.</p>
+    </scopecontent>
+    <separatedmaterial id="aspace_93d92d0c1e70183fc245965ea55d1a8b">
+      <head>Separated Materials</head>
+      <p>This is the Separated Materials note.</p>
+    </separatedmaterial>
+    <userestrict id="aspace_2d8e669a800c026aefc9d7e76ca578c9">
+      <head>Conditions Governing Use</head>
+      <p>This is the Conditions Governing Use note.</p>
+    </userestrict>
+    <altformavail id="aspace_3c14dd8815fd455800c71570138316c6">
+      <head>Existence and Location of Copies</head>
+      <p>This is the Existence and Location of Copies note.</p>
+    </altformavail>
+    <bibliography id="aspace_4eace9a22f9f43be89b214957dbba587">
+      <head>Bibliography</head>
+      <p>This is the Bibliography.</p>
+      <bibref>Adler, Jerry. <title>High <emph render="italic">Rise</emph>.</title>New York: <lb/>
+        <corpname>Harper Collins,</corpname> 1993.</bibref>
+      <bibref>Corruption and Racketeering in the <name>New York City</name> Construction Industry.
+        Interim Report by the New York State Organized Crime Task Force. Ithaca, NY: ILR Press, New
+        York State School of Industrial and Labor Relations, Cornell University, 1988.</bibref>
+      <bibref>Corruption and Racketeering in the New York City Construction Industry. Final Report
+        to <persname>Governor Mario M. Cuomo</persname>. Ronald Goldstock, Director, New York State
+        Organized Crime Task Force. December 1989.</bibref>
+      <bibref><emph render="bold">Ardouin, Charles Nicholas Celigny</emph>. <title render="italic"
+          >Essais sur l'histoire d'Haiti</title>. Port-au-Prince, 1865.</bibref>
+    </bibliography>
+    <controlaccess>
+      <geogname source="lcsh">Boston (Mass.) -- Intellectual life -- 20th century.</geogname>
+      <subject source="lcsh">Irish American women -- History -- 19th century.</subject>
+      <genreform source="aat">Oral histories (literary works)</genreform>
+      <occupation source="lcsh">Fulbright scholars.</occupation>
+      <function source="local">War Powers Conference</function>
+      <title source="local">New York Nichibei.</title>
+      <persname role="dnr" source="naf">Debs, Eugene V. (Eugene Victor), 1855-1926</persname>
+      <corpname role="dnr" source="naf">Tamiment Library</corpname>
+    </controlaccess>
+    <dsc>
+      <c id="aspace_499449c48c751a22b7c222d3ce2c2879" level="series">
+        <did>
+          <unittitle><emph render="italic">Level 2</emph> Series I. <persname>Megan
+              O'Shea</persname>
+            <name>Rolodex</name> on <corpname>New York University</corpname> Here is a
+              <title>title</title></unittitle>
+          <unitid>mos_2021_2</unitid>
+          <origination label="Creator"><corpname source="naf">80 Washington Square East
+              Galleries</corpname></origination>
+          <origination label="Creator"><famname source="local">Blaustein
+            Family</famname></origination>
+          <origination label="Creator"><persname source="naf">Aaron,
+            Florence</persname></origination>
+          <physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">23 Linear
+              Feet</extent><extent altrender="carrier">in 24 record cartons, 1 manuscript box, and 1
+              flat file folder</extent><physfacet>handwritten notes</physfacet><dimensions>24" x
+              24"</dimensions></physdesc>
+          <unitdate normal="2015/2016" type="inclusive">2015-2016</unitdate>
+          <abstract id="aspace_fb8fc30fbb1f790bf2719a30511c5040">Level 2 This is the <emph
+              render="italic">abstract</emph>. It has a <title render="bold" type="book"
+              source="DACS"><emph render="bold">bold</emph>title </title> in it.</abstract>
+          <materialspec id="aspace_8ec8f4ba4cc227c264b552803da8dd5b">Level 2 This is the Materials
+            Specific Details.</materialspec>
+          <physloc id="aspace_ad1c900356662423adac4e02c50f167e">Level 2 This is the Physical
+            Location note.</physloc>
+          <physloc id="aspace_f3cdfc7ba5bcc54f1f0ff7893f0ae71b">Box 152</physloc>
+          <langmaterial id="aspace_d346225d0e8db11008a962db2f193951">Level 2 <emph render="italic"
+              >Materials</emph> are in <language>English</language>.</langmaterial>
+          <container altrender="Record carton" id="aspace_97aeb165b6f69d0120e9d7ce67faac18"
+            label="mixed materials" type="box">1</container>
+          <container id="aspace_3e378514974315119d35e619a686c6d4"
+            parent="aspace_97aeb165b6f69d0120e9d7ce67faac18" type="folder">1</container>
+          <dao xlink:actuate="onRequest" xlink:href="https://hdl.handle.net/2333.1/7h44j74d"
+            xlink:role="audio-service" xlink:show="new" xlink:title="This is a digital object"
+            xlink:type="simple">
+            <daodesc>
+              <p>This is a digital object</p>
+            </daodesc>
+          </dao>
+          <daogrp xlink:title="Archived website of Julie Kathryn" xlink:type="extended">
+            <daodesc>
+              <p>Archived website of Julie Kathryn</p>
+            </daodesc>
+            <daoloc xlink:href="https://wayback.archive-it.org/9900/*/http://www.iamsnowangel.com"
+              xlink:role="external-link" xlink:title="Archived website of Julie Kathryn"
+              xlink:type="locator"/>
+            <daoloc xlink:href="https://wayback.archive-it.org/4049/*/http://www.iamsnowangel.com"
+              xlink:role="external-link" xlink:title="Archived website of Julie Kathryn"
+              xlink:type="locator"/>
+          </daogrp>
+        </did>
+        <accessrestrict id="aspace_ec2c2285331d2824ae8d4c21e73a552f">
+          <head>Conditions Governing <emph render="bold">Access</emph><extptr
+              xlink:href="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+              xlink:show="new"
+              xlink:title="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+              xlink:type="simple"/></head>
+          <p>Level 2 This is the Conditions Governing Access note.</p>
+        </accessrestrict>
+        <accruals id="aspace_19f4f59324d4ae62b7ef7e56745039f8">
+          <head>Accruals</head>
+          <p>Level 2 This is the Accruals note.</p>
+        </accruals>
+        <acqinfo id="aspace_fe2d05d0c6ece43176098328e53f4aa7">
+          <head>Immediate Source of Acquisition</head>
+          <p>Level 2 This is the Immediate Source of Acquisition note.</p>
+        </acqinfo>
+        <appraisal id="aspace_03db3d0296470cb21020f2882c24bd68">
+          <head>Appraisal</head>
+          <p>Level 2 This is the Appraisal note.</p>
+        </appraisal>
+        <arrangement id="aspace_cfbd8ed70f80e9c46e47361081f34805">
+          <head>Arrangement</head>
+          <p>Level 2 This is the Arrangement note.</p>
+        </arrangement>
+        <bioghist id="aspace_c3b852caca83ed640a525cc9c12c1230">
+          <head>Historical Note</head>
+          <p>Level 2 This is the Historical note.</p>
+        </bioghist>
+        <custodhist id="aspace_7833813cd40de517441d95dd27e383f3">
+          <head>Custodial History</head>
+          <p>Level 2 This is the Custodial History note.</p>
+        </custodhist>
+        <fileplan id="aspace_9d92cfbb19d3ab2eae98b3509bb13eb6">
+          <head>File Plan</head>
+          <p>Level 2 This is the File Plan.</p>
+        </fileplan>
+        <odd id="aspace_14d8b5cc06e376f794ada956e2dc3d1a">
+          <head>General</head>
+          <p>This is the Level 2 General note. <address>
+              <addressline>Elmer Holmes Bobst Library</addressline>
+              <addressline>70 Washington Square South</addressline>
+              <addressline>2nd Floor</addressline>
+              <addressline>New York, NY 10012</addressline>
+              <addressline>special.collections@nyu.edu</addressline>
+              <addressline>URL: <extptr
+                  xlink:href="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                  xlink:show="new"
+                  xlink:title="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                  xlink:type="simple"/></addressline>
+            </address>
+            <abbr expan="Autographed Letter Signed">ALS</abbr>
+            <archref>
+              <extref xlink:href="http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/"
+                xlink:title="Sally Belfrage" xlink:type="simple" xlink:show="new">The Sally Belfrage
+                Papers (TAM 189)</extref></archref>
+            <bibref><emph render="bold">Ardouin, Charles Nicholas Celigny</emph>. <title
+                render="italic">Essais sur l'histoire d'Haiti</title>. Port-au-Prince,
+              1865.</bibref>
+            <blockquote>
+              <p>No doubt the estate has exerted a tremendous influence on the development of my
+                character. One may walk for an hour without glimpsing another soul, which has taught
+                me to love tranquility.</p>
+            </blockquote><lb/>
+            <corpname source="naf">Tamiment Library</corpname>
+            <date type="creation">March 2021</date>
+            <list type="deflist" numeration="arabic">
+              <listhead>
+                <head01>Abbreviation</head01>
+                <head02>Expansion</head02>
+              </listhead>
+              <defitem>
+                <label>MIT</label>
+                <item>Massachusetts Institute of Technology</item>
+              </defitem>
+            </list>
+            <genreform source="aat">Oral histories (literary works)</genreform>
+            <name>Rolodex</name>
+            <num type="collection">MOS.2021</num>
+            <occupation source="lcsh">Fulbright scholars.</occupation>
+            <subject source="lcsh">Irish American women -- History -- 19th century.</subject>
+            <list type="deflist">
+              <defitem>
+                <label>MIT</label>
+                <item>Massachusetts Institute of Technology</item>
+              </defitem>
+            </list>
+            <genreform source="aat">Oral histories (literary works)</genreform>
+            <name>Rolodex</name>
+            <num type="collection">MOS.2021</num>
+            <occupation source="lcsh">Fulbright scholars.</occupation>
+            <subject source="lcsh">Irish American women -- History -- 19th century.</subject></p>
+          <list type="deflist">
+            <defitem>
+              <label>MIT</label>
+              <item>Massachusetts Institute of Technology</item>
+            </defitem>
+          </list>
+          <p><genreform source="aat">Oral histories (literary works)</genreform>
+            <name>Rolodex</name>
+            <num type="collection">MOS.2021</num>
+            <occupation source="lcsh">Fulbright scholars.</occupation>
+            <subject source="lcsh">Irish American women -- History -- 19th century.</subject></p>
+          <list type="deflist">
+            <defitem>
+              <label>MIT</label>
+              <item>Massachusetts Institute of Technology</item>
+            </defitem>
+          </list>
+          <p><genreform source="aat">Oral histories (literary works)</genreform>
+            <name>Rolodex</name>
+            <num type="collection">MOS.2021</num>
+            <occupation source="lcsh">Fulbright scholars.</occupation>
+            <subject source="lcsh">Irish American women -- History -- 19th century.</subject></p>
+        </odd>
+        <otherfindaid id="aspace_9724a3d4aa1bf9f723d0abf10571cf3f">
+          <head>Other Finding Aids</head>
+          <p>Level 2 This is the Other Finding Aids note.</p>
+        </otherfindaid>
+        <originalsloc id="aspace_a1b5fbc79910c44817488d250729a686">
+          <head>Existence and Location of Originals</head>
+          <p>Level 2 This is the Existence and Location of Originals note.</p>
+        </originalsloc>
+        <phystech id="aspace_7e8552be007d9fc35331a59e0a831f5a">
+          <head>Physical Characteristics and Technical Requirements</head>
+          <p>Level 2 This is the Physical Characteristics and Technical Requirements note.</p>
+        </phystech>
+        <prefercite id="aspace_59802249b65517da54ed657385362e5b">
+          <head>Preferred Citation</head>
+          <p>Level 2 This is the Preferred Citation note.</p>
+        </prefercite>
+        <processinfo id="aspace_703aa9981288e97d16c6e3bd32ca5b22">
+          <head>Processing Information</head>
+          <p>Level 2 This is the Processing Information note.</p>
+        </processinfo>
+        <relatedmaterial id="aspace_2ed7b9e4dd352111e89a909ba78dfca4">
+          <head>Related Materials</head>
+          <p>Level 2 This is the Related Materials note.</p>
+        </relatedmaterial>
+        <scopecontent id="aspace_dfac3eae96d7fc3be099ae7fa8bd22e3">
+          <head>Scope and Contents</head>
+          <p>Level 2 This is the Scope and Content note.</p>
+        </scopecontent>
+        <separatedmaterial id="aspace_f2ccd75f63f83d36ad8222b582035a6b">
+          <head>Separated Materials</head>
+          <p>Level 2 This is the Separated Materials note. <archref><physloc>Box
+              152</physloc></archref></p>
+        </separatedmaterial>
+        <userestrict id="aspace_2a50b40dffc6e51c474e021a377e8d5c">
+          <head>Conditions Governing Use</head>
+          <p>Level 2 This is the Conditions Governing Use note.</p>
+        </userestrict>
+        <index id="aspace_4793fb5ebba78bde4487e0c1b06e788a">
+          <head>This is the Index head.</head>
+          <p>Level 2 This is the Index.</p>
+          <indexentry>
+            <corpname>Level 2 Index term 1</corpname>
+          </indexentry>
+          <indexentry>
+            <name>Level 2 Index term 2</name>
+          </indexentry>
+          <indexentry>
+            <subject>Level 2 Index term 3</subject>
+          </indexentry>
+        </index>
+        <controlaccess>
+          <geogname source="lcsh">Boston (Mass.) -- Intellectual life -- 20th century.</geogname>
+          <subject source="lcsh">Irish American women -- History -- 19th century.</subject>
+          <genreform source="aat">Oral histories (literary works)</genreform>
+          <occupation source="lcsh">Fulbright scholars.</occupation>
+          <function source="local">War Powers Conference</function>
+          <corpname source="naf">Tamiment Library</corpname>
+          <famname rules="dacs" source="local">Belfrage family</famname>
+        </controlaccess>
+        <c id="aspace_68fd22d28746c12f37e250728431c61d" level="subseries">
+          <did>
+            <unittitle><emph render="italic">Level 3</emph> Series I. <persname>Megan
+                O'Shea</persname>
+              <name>Rolodex</name> on <corpname>New York University</corpname> Here is a
+                <title>title</title></unittitle>
+            <unitid>mos_2021_3</unitid>
+            <origination label="Creator"><corpname rules="dacs" source="naf">9 to 5, National
+                Association of Working Women (U.S.)</corpname></origination>
+            <origination label="Creator"><famname source="local">Chen family</famname></origination>
+            <origination label="Creator"><persname rules="dacs" source="local">Adams, B.
+                O.</persname></origination>
+            <physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">12 Linear
+                Feet</extent><extent altrender="carrier">in 24 record cartons, 1 manuscript box, and
+                1 flat file folder</extent><physfacet>Hopefully perfectly this is
+                correct</physfacet><dimensions>12" x 12"</dimensions></physdesc>
+            <unitdate normal="2021/2021" type="inclusive">2021</unitdate>
+            <abstract id="aspace_b96a3528d042efb6eb39fc9ee28012f7">Level 3 This is the <emph
+                render="italic">Abstract</emph>. It has a <title render="bold" type="book"
+                source="DACS"><emph render="bold">bold </emph>title</title> in it.</abstract>
+            <materialspec id="aspace_90c738fbc387b6372a896966a814da87">Level 3 This is the Materials
+              Specific Details note.</materialspec>
+            <physdesc id="aspace_ad2690d144d7a56a4753497bf80c043b" label="Physical Description"
+              >Level 3 This is the Physical Description note.</physdesc>
+            <physloc id="aspace_afd9ea8072f07c5f9bcce1d4a37d1b69">Level 3 This is the Physical
+              Location note.</physloc>
+            <physloc id="aspace_0790e3e9da2aa63ac821c43c3823a5ea">Box 152</physloc>
+            <langmaterial id="aspace_1676961983c252b748ee5d2ed7bce91c">Level 3 <emph render="italic"
+                >Materials</emph> are in <language>English</language>.</langmaterial>
+            <container altrender="Record carton" id="aspace_b5536d690c48c6b42f3faa9fe07082d1"
+              label="mixed materials" type="box">1</container>
+            <container id="aspace_8a79b91fe93c7f65091573245ae4c7a2"
+              parent="aspace_b5536d690c48c6b42f3faa9fe07082d1" type="folder">1</container>
+            <daogrp xlink:title="Archived website of Julie Kathryn" xlink:type="extended">
+              <daodesc>
+                <p>Archived website of Julie Kathryn</p>
+              </daodesc>
+              <daoloc xlink:href="https://wayback.archive-it.org/9900/*/http://www.iamsnowangel.com"
+                xlink:role="external-link" xlink:title="Archived website of Julie Kathryn"
+                xlink:type="locator"/>
+              <daoloc xlink:href="https://wayback.archive-it.org/4049/*/http://www.iamsnowangel.com"
+                xlink:role="external-link" xlink:title="Archived website of Julie Kathryn"
+                xlink:type="locator"/>
+            </daogrp>
+            <dao xlink:actuate="onRequest" xlink:href="https://hdl.handle.net/2333.1/34tmpk87"
+              xlink:role="video-service" xlink:show="new" xlink:title="This is a digital object"
+              xlink:type="simple">
+              <daodesc>
+                <p>This is a digital object</p>
+              </daodesc>
+            </dao>
+          </did>
+          <accessrestrict id="aspace_818a64a65aec3301db238f513d232538">
+            <head>Conditions Governing <emph render="bold">Access</emph><extptr
+                xlink:href="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                xlink:show="new"
+                xlink:title="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                xlink:type="simple"/></head>
+            <p>Level 3 This is the Conditions Governing Access note.</p>
+          </accessrestrict>
+          <accruals id="aspace_24307e8faf8521203474d580d126ab79">
+            <head>Accruals</head>
+            <p>Level 3 This is the Accruals note.</p>
+          </accruals>
+          <acqinfo id="aspace_8b2c6d8b5a9b524962773d44488b0724">
+            <head>Immediate Source of Acquisition</head>
+            <p>Level 3 This is the Immediate Source of Acquisition note.</p>
+          </acqinfo>
+          <appraisal id="aspace_5af491aeee5421d484748713f0d21e07">
+            <head>Appraisal</head>
+            <p>Level 3 This is the Appraisal note.</p>
+          </appraisal>
+          <arrangement id="aspace_3e705b21424f2473489b1aba513c8701">
+            <head>Arrangement</head>
+            <p>Level 3 This is the Arrangement note.</p>
+          </arrangement>
+          <bioghist id="aspace_44878fdbd29194369fed682088365a06">
+            <head>Biographical note</head>
+            <p>Level 3 This is the Biographical note.</p>
+          </bioghist>
+          <custodhist id="aspace_c7910bb4048953951f92b21d61c08e6a">
+            <head>Custodial History</head>
+            <p>Level 3 This is the Custodial History note.</p>
+          </custodhist>
+          <fileplan id="aspace_3a7edd9aa5f5261303082c6cd68b21fb">
+            <head>File Plan</head>
+            <p>Level 3 This is the File Plan.</p>
+          </fileplan>
+          <odd id="aspace_65945cf78ff0356fdf7b1561e062f16d">
+            <head>General</head>
+            <p>This is the Level 3 General note. <address>
+                <addressline>Elmer Holmes Bobst Library</addressline>
+                <addressline>70 Washington Square South</addressline>
+                <addressline>2nd Floor</addressline>
+                <addressline>New York, NY 10012</addressline>
+                <addressline>special.collections@nyu.edu</addressline>
+                <addressline>URL: <extptr
+                    xlink:href="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                    xlink:show="new"
+                    xlink:title="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                    xlink:type="simple"/></addressline>
+              </address>
+              <abbr expan="Autographed Letter Signed">ALS</abbr>
+              <archref>
+                <extref xlink:href="http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/"
+                  xlink:title="Sally Belfrage" xlink:type="simple" xlink:show="new">The Sally
+                  Belfrage Papers (TAM 189)</extref></archref>
+              <bibref><emph render="bold">Ardouin, Charles Nicholas Celigny</emph>. <title
+                  render="italic">Essais sur l'histoire d'Haiti</title>. Port-au-Prince,
+                1865.</bibref>
+              <blockquote>
+                <p>No doubt the estate has exerted a tremendous influence on the development of my
+                  character. One may walk for an hour without glimpsing another soul, which has
+                  taught me to love tranquility.</p>
+              </blockquote><lb/>
+              <corpname source="naf">Tamiment Library</corpname>
+              <date type="creation">March 2021</date>
+              <list type="deflist" numeration="arabic">
+                <listhead>
+                  <head01>Abbreviation</head01>
+                  <head02>Expansion</head02>
+                </listhead>
+                <defitem>
+                  <label>MIT</label>
+                  <item>Massachusetts Institute of Technology</item>
+                </defitem>
+              </list>
+              <genreform source="aat">Oral histories (literary works)</genreform>
+              <name>Rolodex</name>
+              <num type="collection">MOS.2021</num>
+              <occupation source="lcsh">Fulbright scholars.</occupation>
+              <subject source="lcsh">Irish American women -- History -- 19th century.</subject>
+              <list type="deflist">
+                <defitem>
+                  <label>MIT</label>
+                  <item>Massachusetts Institute of Technology</item>
+                </defitem>
+              </list>
+              <genreform source="aat">Oral histories (literary works)</genreform>
+              <name>Rolodex</name>
+              <num type="collection">MOS.2021</num>
+              <occupation source="lcsh">Fulbright scholars.</occupation>
+              <subject source="lcsh">Irish American women -- History -- 19th century.</subject></p>
+            <list type="deflist">
+              <defitem>
+                <label>MIT</label>
+                <item>Massachusetts Institute of Technology</item>
+              </defitem>
+            </list>
+            <p><genreform source="aat">Oral histories (literary works)</genreform>
+              <name>Rolodex</name>
+              <num type="collection">MOS.2021</num>
+              <occupation source="lcsh">Fulbright scholars.</occupation>
+              <subject source="lcsh">Irish American women -- History -- 19th century.</subject></p>
+            <list type="deflist">
+              <defitem>
+                <label>MIT</label>
+                <item>Massachusetts Institute of Technology</item>
+              </defitem>
+            </list>
+            <p><genreform source="aat">Oral histories (literary works)</genreform>
+              <name>Rolodex</name>
+              <num type="collection">MOS.2021</num>
+              <occupation source="lcsh">Fulbright scholars.</occupation>
+              <subject source="lcsh">Irish American women -- History -- 19th century.</subject></p>
+          </odd>
+          <otherfindaid id="aspace_f752b0a547efbc69593268b979035730">
+            <head>Other Finding Aids</head>
+            <p>Level 3 This is the Other Finding Aids note.</p>
+          </otherfindaid>
+          <originalsloc id="aspace_63787a39fe65c3530f57167e2d2b3479">
+            <head>Existence and Location of Originals</head>
+            <p>Level 3 This is the Existence and Location of Originals note.</p>
+          </originalsloc>
+          <phystech id="aspace_9457c04ac099016322bacfa5e3f8c134">
+            <head>Physical Characteristics and Technical Requirements</head>
+            <p>Level 3 This is the Physical Characteristics and Technical Requirements note.</p>
+          </phystech>
+          <prefercite id="aspace_9a9f8b796bc9b4ae0b177cdc7f4b26e5">
+            <head>Preferred Citation</head>
+            <p>Level 3 This is the Preferred Citation note.</p>
+          </prefercite>
+          <processinfo id="aspace_08acbdeac7c85e295f622c726791b736">
+            <head>Processing Information</head>
+            <p>Level 3 This is the Processing Information note.</p>
+          </processinfo>
+          <relatedmaterial id="aspace_800b52132f1e955130a00bfa732ab9e6">
+            <head>Related Materials</head>
+            <p>Level 3 This is the Related Materials note.</p>
+          </relatedmaterial>
+          <scopecontent id="aspace_5a26daae9c40e27a40cfb1ab51f8d06b">
+            <head>Scope and Contents</head>
+            <p>Level 3 This is the Scope and Content note.</p>
+          </scopecontent>
+          <separatedmaterial id="aspace_c69ecb09a1481b003fdd5772eaafc419">
+            <head>Separated Materials</head>
+            <p>Level 3 This is the Separated Materials note. <archref><physloc>Box
+                152</physloc></archref></p>
+          </separatedmaterial>
+          <userestrict id="aspace_17b8b10cf5a81a95c0b8cf6e7eefb11c">
+            <head>Conditions Governing Use</head>
+            <p>Level 3 This is the Conditions Governing Use note.</p>
+          </userestrict>
+          <index id="aspace_abe974fea759a049d62f70ee41835af4">
+            <head>Index head</head>
+            <p>Level 3 This is the Index.</p>
+            <indexentry>
+              <corpname>Level 3 Index item</corpname>
+            </indexentry>
+          </index>
+          <controlaccess>
+            <geogname source="lcsh">Boston (Mass.) -- Intellectual life -- 20th century.</geogname>
+            <subject source="lcsh">Irish American women -- History -- 19th century.</subject>
+            <genreform source="aat">Oral histories (literary works)</genreform>
+            <occupation source="lcsh">Fulbright scholars.</occupation>
+            <function source="local">War Powers Conference</function>
+            <corpname source="naf">Tamiment Library</corpname>
+            <famname rules="dacs" source="local">Belfrage family</famname>
+          </controlaccess>
+          <c id="aspace_f35efa0f6a068b57a2d396067e4f7427" level="subseries">
+            <did>
+              <unittitle><emph render="italic">Level 4</emph> Series I. <persname>Megan
+                  O'Shea</persname>
+                <name>Rolodex</name> on <corpname>New York University</corpname> Here is a
+                  <title>title</title></unittitle>
+              <unitid>mos_2021_4</unitid>
+              <origination label="Creator"><corpname source="naf">Yivo Institute for Jewish
+                  Research</corpname></origination>
+              <origination label="Creator"><famname rules="dacs" source="local">Pinsof
+                  family</famname></origination>
+              <origination label="Creator"><persname source="naf">Zwillinger,
+                Rhonda</persname></origination>
+              <physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">2 Linear
+                  Feet</extent><extent altrender="carrier">in 24 record cartons, 1 manuscript box,
+                  and 1 flat file folder</extent><physfacet>This is a test</physfacet><dimensions>1'
+                  x 27"</dimensions></physdesc>
+              <unitdate normal="2017/2019" type="inclusive">2017-2019</unitdate>
+              <abstract id="aspace_3d9720d0bacf6d3d15ac94b5ce37e689">Level 4 <emph render="italic"
+                  >This</emph> is the <title>Abstract</title>.It has a <title render="bold"
+                  type="book" source="DACS"><emph render="bold">bold </emph>title</title> in
+                it.</abstract>
+              <materialspec id="aspace_bb766f2f7183c55973b1b8097f44002f">Level 4 This is the
+                Materials Specific Details note.</materialspec>
+              <physdesc id="aspace_478bdf2b485ef16a9da865d1deef629c" label="Physical Description"
+                >Level 4 This is the Physical Description note.</physdesc>
+              <physloc id="aspace_b6521902953af6f8eb7c33b079f834df">Level 4 This is the Physical
+                Location note.</physloc>
+              <physloc id="aspace_aec0166edc173f05326763b6b488cf26">Box 152</physloc>
+              <langmaterial id="aspace_e89995070ff1a0de51f06a08c03193c7">Level 4 <emph render="bold"
+                  >Materials</emph> in <language>English</language>.</langmaterial>
+              <container altrender="Record carton" id="aspace_277369e5dfa81775c973da42ed84b647"
+                label="mixed materials" type="box">1</container>
+              <container id="aspace_0e914532f0cc92734c6e1100bd0d6af1"
+                parent="aspace_277369e5dfa81775c973da42ed84b647" type="folder">1</container>
+              <daogrp xlink:title="Archived website of Julie Kathryn" xlink:type="extended">
+                <daodesc>
+                  <p>Archived website of Julie Kathryn</p>
+                </daodesc>
+                <daoloc
+                  xlink:href="https://wayback.archive-it.org/9900/*/http://www.iamsnowangel.com"
+                  xlink:role="external-link" xlink:title="Archived website of Julie Kathryn"
+                  xlink:type="locator"/>
+                <daoloc
+                  xlink:href="https://wayback.archive-it.org/4049/*/http://www.iamsnowangel.com"
+                  xlink:role="external-link" xlink:title="Archived website of Julie Kathryn"
+                  xlink:type="locator"/>
+              </daogrp>
+              <dao xlink:actuate="onRequest" xlink:href="https://hdl.handle.net/2333.1/m63xss7g"
+                xlink:role="image-service" xlink:show="new" xlink:title="This is a digital object"
+                xlink:type="simple">
+                <daodesc>
+                  <p>This is a digital object</p>
+                </daodesc>
+              </dao>
+            </did>
+            <accessrestrict id="aspace_a6d071b6ad4eb8400fc708ab7e393136">
+              <head>Conditions Governing <emph render="bold">Access</emph><extptr
+                  xlink:href="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                  xlink:show="new"
+                  xlink:title="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                  xlink:type="simple"/></head>
+              <p>Level 4 This is the Conditions Governing Access note.</p>
+            </accessrestrict>
+            <accruals id="aspace_b563af80b992113e66b83b7467357813">
+              <head>Accruals</head>
+              <p>Level 4 This is the Accruals note.</p>
+            </accruals>
+            <acqinfo id="aspace_12a46dab225b86dac76a34817cd9be6a">
+              <head>Immediate Source of Acquisition</head>
+              <p>Level 4 This is the Immediate Source of Acquisition note.</p>
+            </acqinfo>
+            <appraisal id="aspace_e40cf639d4a8e85ae1da694532c4d750">
+              <head>Appraisal</head>
+              <p>Level 4 This is the Appraisal note.</p>
+            </appraisal>
+            <arrangement id="aspace_bc17a8237c1f92971b51dca841d298be">
+              <head>Arrangement</head>
+              <p>Level 4 This is the Arrangement note.</p>
+            </arrangement>
+            <bioghist id="aspace_cab5bf3424cb6a76e09f80c5d02d322c">
+              <head>Biographical note</head>
+              <p>Level 4 This is the Biographical note.</p>
+            </bioghist>
+            <custodhist id="aspace_cd438d2283bbc46dba9b6bf0e3bfd48f">
+              <head>Custodial History</head>
+              <p>Level 4 This is the Custodial History note.</p>
+            </custodhist>
+            <fileplan id="aspace_263cb0600aa30a376f230fdd767ef140">
+              <head>File Plan</head>
+              <p>Level 4 This is the File Plan.</p>
+            </fileplan>
+            <odd id="aspace_5663cc33576c4f60a114a09d5372c8fe">
+              <head>General</head>
+              <p>This is the Level 4 General note. <address>
+                  <addressline>Elmer Holmes Bobst Library</addressline>
+                  <addressline>70 Washington Square South</addressline>
+                  <addressline>2nd Floor</addressline>
+                  <addressline>New York, NY 10012</addressline>
+                  <addressline>special.collections@nyu.edu</addressline>
+                  <addressline>URL: <extptr
+                      xlink:href="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                      xlink:show="new"
+                      xlink:title="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                      xlink:type="simple"/></addressline>
+                </address>
+                <abbr expan="Autographed Letter Signed">ALS</abbr>
+                <archref>
+                  <extref xlink:href="http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/"
+                    xlink:title="Sally Belfrage" xlink:type="simple" xlink:show="new">The Sally
+                    Belfrage Papers (TAM 189)</extref></archref>
+                <bibref><emph render="bold">Ardouin, Charles Nicholas Celigny</emph>. <title
+                    render="italic">Essais sur l'histoire d'Haiti</title>. Port-au-Prince,
+                  1865.</bibref>
+                <blockquote>
+                  <p>No doubt the estate has exerted a tremendous influence on the development of my
+                    character. One may walk for an hour without glimpsing another soul, which has
+                    taught me to love tranquility.</p>
+                </blockquote><lb/>
+                <corpname source="naf">Tamiment Library</corpname>
+                <date type="creation">March 2021</date>
+                <list type="deflist" numeration="arabic">
+                  <listhead>
+                    <head01>Abbreviation</head01>
+                    <head02>Expansion</head02>
+                  </listhead>
+                  <defitem>
+                    <label>MIT</label>
+                    <item>Massachusetts Institute of Technology</item>
+                  </defitem>
+                </list>
+                <genreform source="aat">Oral histories (literary works)</genreform>
+                <name>Rolodex</name>
+                <num type="collection">MOS.2021</num>
+                <occupation source="lcsh">Fulbright scholars.</occupation>
+                <subject source="lcsh">Irish American women -- History -- 19th century.</subject>
+                <list type="deflist">
+                  <defitem>
+                    <label>MIT</label>
+                    <item>Massachusetts Institute of Technology</item>
+                  </defitem>
+                </list>
+                <genreform source="aat">Oral histories (literary works)</genreform>
+                <name>Rolodex</name>
+                <num type="collection">MOS.2021</num>
+                <occupation source="lcsh">Fulbright scholars.</occupation>
+                <subject source="lcsh">Irish American women -- History -- 19th
+                century.</subject></p>
+              <list type="deflist">
+                <defitem>
+                  <label>MIT</label>
+                  <item>Massachusetts Institute of Technology</item>
+                </defitem>
+              </list>
+              <p><genreform source="aat">Oral histories (literary works)</genreform>
+                <name>Rolodex</name>
+                <num type="collection">MOS.2021</num>
+                <occupation source="lcsh">Fulbright scholars.</occupation>
+                <subject source="lcsh">Irish American women -- History -- 19th
+                century.</subject></p>
+              <list type="deflist">
+                <defitem>
+                  <label>MIT</label>
+                  <item>Massachusetts Institute of Technology</item>
+                </defitem>
+              </list>
+              <p><genreform source="aat">Oral histories (literary works)</genreform>
+                <name>Rolodex</name>
+                <num type="collection">MOS.2021</num>
+                <occupation source="lcsh">Fulbright scholars.</occupation>
+                <subject source="lcsh">Irish American women -- History -- 19th
+                century.</subject></p>
+            </odd>
+            <otherfindaid id="aspace_30e9a550325592d2c580ae2fa14bad16">
+              <head>Other Finding Aids</head>
+              <p>Level 4 This is the Other Finding Aids note.</p>
+            </otherfindaid>
+            <originalsloc id="aspace_9c9019e5330b43c5aff473a3cb2e6c04">
+              <head>Existence and Location of Originals</head>
+              <p>Level 4 This is the Existence and Location of Originals note.</p>
+            </originalsloc>
+            <phystech id="aspace_cb37b719b582123d998dff13855d5343">
+              <head>Physical Characteristics and Technical Requirements</head>
+              <p>Level 4 This is the Physical Characteristics and Technical Requirements note.</p>
+            </phystech>
+            <prefercite id="aspace_caee1a0b9dcfc598055681a91291f2bb">
+              <head>Preferred Citation</head>
+              <p>Level 4 This is the Preferred Citation note.</p>
+            </prefercite>
+            <processinfo id="aspace_1abcc14a1a9bf406c9c3856ddd01d794">
+              <head>Processing Information</head>
+              <p>Level 4 This is the Processing Information note.</p>
+            </processinfo>
+            <relatedmaterial id="aspace_37d44617b518963f97002b3a32ec14be">
+              <head>Related Materials</head>
+              <p>Level 4 This is the Related Materials note.</p>
+            </relatedmaterial>
+            <scopecontent id="aspace_7d9603f358e3cb5551b55cee34a0f85a">
+              <head>Scope and Contents</head>
+              <p>Level 4 This is the Scope and Content note.</p>
+            </scopecontent>
+            <separatedmaterial id="aspace_ce804033f1c4a4f7a47d1ae23b8a82b0">
+              <head>Separated Materials</head>
+              <p>Level 4 This is the Separated Materials note. <archref><physloc>Box
+                  152</physloc></archref></p>
+            </separatedmaterial>
+            <userestrict id="aspace_2f463c22696e1024a8eda0a1f251b16f">
+              <head>Conditions Governing Use</head>
+              <p>Level 4 This is the Conditions Governing Use note.</p>
+            </userestrict>
+            <index id="aspace_472965efae0a7e6f937feb7775d565c6">
+              <head>Index head</head>
+              <p>Level 4 This is the Index.</p>
+              <indexentry>
+                <corpname>Level 4 Index item</corpname>
+              </indexentry>
+            </index>
+            <controlaccess>
+              <geogname source="lcsh">Boston (Mass.) -- Intellectual life -- 20th
+                century.</geogname>
+              <subject source="lcsh">Irish American women -- History -- 19th century.</subject>
+              <genreform source="aat">Oral histories (literary works)</genreform>
+              <occupation source="lcsh">Fulbright scholars.</occupation>
+              <function source="local">War Powers Conference</function>
+              <corpname source="naf">Tamiment Library</corpname>
+              <famname rules="dacs" source="local">Belfrage family</famname>
+            </controlaccess>
+            <c id="aspace_a8e8b321d84febb7aee747f54e624fc4" level="subseries">
+              <did>
+                <unittitle><emph render="italic">Level 5</emph> Series I. <persname>Megan
+                    O'Shea</persname>
+                  <name>Rolodex</name>
+                  <lb/>on <corpname>New York University</corpname> Here is a
+                  <title>title</title></unittitle>
+                <unitid>mos_2021_5</unitid>
+                <origination label="Creator"><corpname rules="aacr" source="naf">World Trade Center
+                    (New York, N.Y.)</corpname></origination>
+                <origination label="Creator"><famname source="local">Draper
+                  family</famname></origination>
+                <origination label="Creator"><persname source="naf">Yonge, Charlotte Mary,
+                    1823-1901</persname></origination>
+                <physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">5 Linear
+                    Feet</extent><extent altrender="carrier">in 24 record cartons, 1 manuscript box,
+                    and 1 flat file folder</extent><physfacet>This is still a
+                    test</physfacet><dimensions>7" x 45'</dimensions></physdesc>
+                <unitdate normal="2015/2019" type="inclusive">2015-2019</unitdate>
+                <abstract id="aspace_249a3fdd9a6970f7261ef73ed5a82c33">Level 5 <emph render="bold"
+                    >This is</emph> the <title>Abstract</title>. It has a <title render="bold"
+                    type="book" source="DACS"><emph render="bold">bold </emph>title</title> in
+                  it.</abstract>
+                <materialspec id="aspace_ed591019ee2e31b0ed6321587349ae04">Level 5 This is the
+                  Materials Specific Details note.</materialspec>
+                <physdesc id="aspace_28df7326e65493e2fc1ec9654617ef0e" label="Physical Description"
+                  >Level 5 This is the Physical Description note.</physdesc>
+                <physloc id="aspace_a56d52abb5da53cd39c1a7594080266b">Level 5 This is the Physical
+                  Location note.</physloc>
+                <physloc id="aspace_f08355ba37e1a342766ef0031cf92f7c">Box 152</physloc>
+                <langmaterial id="aspace_9b0efe097064eb3e852f801492847a37">Level 5 <emph
+                    render="italic">Materials</emph> are in
+                  <language>English</language>.</langmaterial>
+                <container altrender="Record carton" id="aspace_9fc2c4c89b5765e325dd8ece336e4fc5"
+                  label="mixed materials" type="box">1</container>
+                <container id="aspace_663e58ec96e9f1a1ff597923c2c9c766"
+                  parent="aspace_9fc2c4c89b5765e325dd8ece336e4fc5" type="folder">1</container>
+                <daogrp xlink:title="Archived website of Julie Kathryn" xlink:type="extended">
+                  <daodesc>
+                    <p>Archived website of Julie Kathryn</p>
+                  </daodesc>
+                  <daoloc
+                    xlink:href="https://wayback.archive-it.org/9900/*/http://www.iamsnowangel.com"
+                    xlink:role="external-link" xlink:title="Archived website of Julie Kathryn"
+                    xlink:type="locator"/>
+                  <daoloc
+                    xlink:href="https://wayback.archive-it.org/4049/*/http://www.iamsnowangel.com"
+                    xlink:role="external-link" xlink:title="Archived website of Julie Kathryn"
+                    xlink:type="locator"/>
+                </daogrp>
+                <dao xlink:actuate="onRequest" xlink:href="https://hdl.handle.net/2333.1/xgxd28gq"
+                  xlink:role="image-service" xlink:show="new" xlink:title="This is a digital object"
+                  xlink:type="simple">
+                  <daodesc>
+                    <p>This is a digital object</p>
+                  </daodesc>
+                </dao>
+              </did>
+              <accessrestrict id="aspace_346f8529644844c23c573252cfddf5c6">
+                <head>Conditions Governing <emph render="bold">Access</emph><extptr
+                    xlink:href="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                    xlink:show="new"
+                    xlink:title="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                    xlink:type="simple"/></head>
+                <p>Level 5 This is the Conditions Governing Access note.</p>
+              </accessrestrict>
+              <accruals id="aspace_c6d0b18bc1ed738be695d4c2de144f1a">
+                <head>Accruals</head>
+                <p>Level 5 This is the Accruals note.</p>
+              </accruals>
+              <acqinfo id="aspace_5166484a658f95efdab1b8f8ec7f0e40">
+                <head>Immediate Source of Acquisition</head>
+                <p>Level 5 This is the Immediate Source of Acquisition note.</p>
+              </acqinfo>
+              <appraisal id="aspace_15fe109c0bd60dbaf1eff70fa2c4d25e">
+                <head>Appraisal</head>
+                <p>Level 5 This is the Appraisal note.</p>
+              </appraisal>
+              <arrangement id="aspace_a263870a70533b6b5b78051352ba3315">
+                <head>Arrangement</head>
+                <p>Level 5 This is the Arrangement note.</p>
+              </arrangement>
+              <bioghist id="aspace_b615c8b6866a3abc8c6aebe0f2307689">
+                <head>Biographical note</head>
+                <p>Level 5 This is the Biographical note.</p>
+              </bioghist>
+              <custodhist id="aspace_a0164cc049fccf4f6e35d807eba828ae">
+                <head>Custodial History</head>
+                <p>Level 5 This is the Custodial History note.</p>
+              </custodhist>
+              <fileplan id="aspace_157a5a813a2ad425952ce917fc18e4fe">
+                <head>File Plan</head>
+                <p>Level 5 This is the File Plan.</p>
+              </fileplan>
+              <odd id="aspace_b4c220c97316431abaf744f6444e431d">
+                <head>General</head>
+                <p>This is the Level 5 General note. <address>
+                    <addressline>Elmer Holmes Bobst Library</addressline>
+                    <addressline>70 Washington Square South</addressline>
+                    <addressline>2nd Floor</addressline>
+                    <addressline>New York, NY 10012</addressline>
+                    <addressline>special.collections@nyu.edu</addressline>
+                    <addressline>URL: <extptr
+                        xlink:href="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                        xlink:show="new"
+                        xlink:title="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                        xlink:type="simple"/></addressline>
+                  </address>
+                  <abbr expan="Autographed Letter Signed">ALS</abbr>
+                  <archref>
+                    <extref xlink:href="http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/"
+                      xlink:title="Sally Belfrage" xlink:type="simple" xlink:show="new">The Sally
+                      Belfrage Papers (TAM 189)</extref></archref>
+                  <bibref><emph render="bold">Ardouin, Charles Nicholas Celigny</emph>. <title
+                      render="italic">Essais sur l'histoire d'Haiti</title>. Port-au-Prince,
+                    1865.</bibref>
+                  <blockquote>
+                    <p>No doubt the estate has exerted a tremendous influence on the development of
+                      my character. One may walk for an hour without glimpsing another soul, which
+                      has taught me to love tranquility.</p>
+                  </blockquote><lb/>
+                  <corpname source="naf">Tamiment Library</corpname>
+                  <date type="creation">March 2021</date>
+                  <list type="deflist" numeration="arabic">
+                    <listhead>
+                      <head01>Abbreviation</head01>
+                      <head02>Expansion</head02>
+                    </listhead>
+                    <defitem>
+                      <label>MIT</label>
+                      <item>Massachusetts Institute of Technology</item>
+                    </defitem>
+                  </list>
+                  <genreform source="aat">Oral histories (literary works)</genreform>
+                  <name>Rolodex</name>
+                  <num type="collection">MOS.2021</num>
+                  <occupation source="lcsh">Fulbright scholars.</occupation>
+                  <subject source="lcsh">Irish American women -- History -- 19th century.</subject>
+                  <list type="deflist">
+                    <defitem>
+                      <label>MIT</label>
+                      <item>Massachusetts Institute of Technology</item>
+                    </defitem>
+                  </list>
+                  <genreform source="aat">Oral histories (literary works)</genreform>
+                  <name>Rolodex</name>
+                  <num type="collection">MOS.2021</num>
+                  <occupation source="lcsh">Fulbright scholars.</occupation>
+                  <subject source="lcsh">Irish American women -- History -- 19th
+                  century.</subject></p>
+                <list type="deflist">
+                  <defitem>
+                    <label>MIT</label>
+                    <item>Massachusetts Institute of Technology</item>
+                  </defitem>
+                </list>
+                <p><genreform source="aat">Oral histories (literary works)</genreform>
+                  <name>Rolodex</name>
+                  <num type="collection">MOS.2021</num>
+                  <occupation source="lcsh">Fulbright scholars.</occupation>
+                  <subject source="lcsh">Irish American women -- History -- 19th
+                  century.</subject></p>
+                <list type="deflist">
+                  <defitem>
+                    <label>MIT</label>
+                    <item>Massachusetts Institute of Technology</item>
+                  </defitem>
+                </list>
+                <p><genreform source="aat">Oral histories (literary works)</genreform>
+                  <name>Rolodex</name>
+                  <num type="collection">MOS.2021</num>
+                  <occupation source="lcsh">Fulbright scholars.</occupation>
+                  <subject source="lcsh">Irish American women -- History -- 19th
+                  century.</subject></p>
+              </odd>
+              <otherfindaid id="aspace_095dd2c0215f9cb9f18f3cd47ae78ad1">
+                <head>Other Finding Aids</head>
+                <p>Level 5 This is the Other Finding Aids note.</p>
+              </otherfindaid>
+              <originalsloc id="aspace_b1baecf704266074bb5ed0668bd48664">
+                <head>Existence and Location of Originals</head>
+                <p>Level 5 This is the Existence and Location of Originals note.</p>
+              </originalsloc>
+              <phystech id="aspace_9a810d283ec1171c095471c97584356a">
+                <head>Physical Characteristics and Technical Requirements</head>
+                <p>Level 5 This is the Physical Characteristics and Technical Requirements note.</p>
+              </phystech>
+              <prefercite id="aspace_da13d87ab539adcb04d8cc4788a403a2">
+                <head>Preferred Citation</head>
+                <p>Level 5 This is the Preferred Citation note.</p>
+              </prefercite>
+              <processinfo id="aspace_489f3c28a4edd7f9c35caf86eda1c3e4">
+                <head>Processing Information</head>
+                <p>Level 5 This is the Processing Information note.</p>
+              </processinfo>
+              <relatedmaterial id="aspace_3effcf63108f278a01b02287bb608ea1">
+                <head>Related Materials</head>
+                <p>Level 5 This is the Related Materials note.</p>
+              </relatedmaterial>
+              <scopecontent id="aspace_c4d67d6cbeab9c4e9fc0e6848d58de22">
+                <head>Scope and Contents</head>
+                <p>Level 5 This is the Scope and Content note.</p>
+              </scopecontent>
+              <separatedmaterial id="aspace_32388aa060e68f3a9b9c3c603bb61013">
+                <head>Separated Materials</head>
+                <p>Level 5 This is the Separated Materials note. <archref><physloc>Box
+                    152</physloc></archref></p>
+              </separatedmaterial>
+              <userestrict id="aspace_3b4710103c1ea86472fd2ba940d2bc34">
+                <head>Conditions Governing Use</head>
+                <p>Level 5 This is the Conditions Governing Use note.</p>
+              </userestrict>
+              <index id="aspace_e6ff06ec5d33f393d3622b04ba54e7e1">
+                <head>Index head</head>
+                <p>Level 5 This is the Index.</p>
+                <indexentry>
+                  <corpname>Level 5 Index Item</corpname>
+                </indexentry>
+              </index>
+              <controlaccess>
+                <geogname source="lcsh">Boston (Mass.) -- Intellectual life -- 20th
+                  century.</geogname>
+                <subject source="lcsh">Irish American women -- History -- 19th century.</subject>
+                <genreform source="aat">Oral histories (literary works)</genreform>
+                <occupation source="lcsh">Fulbright scholars.</occupation>
+                <function source="local">War Powers Conference</function>
+                <corpname source="naf">Tamiment Library</corpname>
+                <famname rules="dacs" source="local">Belfrage family</famname>
+              </controlaccess>
+              <c id="aspace_bb018068fcbef8e42d90b29434d476d6" level="file">
+                <did>
+                  <unittitle><emph render="italic">Level 6</emph> Series I. <persname>Megan
+                      O'Shea</persname>
+                    <name>Rolodex</name> on <corpname>New York University</corpname> Here is a
+                      <title>title</title></unittitle>
+                  <unitid>mos_2021_6</unitid>
+                  <origination label="Creator"><corpname source="naf">Workers' Party of
+                      Ireland</corpname></origination>
+                  <origination label="Creator"><famname source="local">Blaustein
+                    Family</famname></origination>
+                  <origination label="Creator"><persname source="naf">Alum, Rolando
+                    A.</persname></origination>
+                  <physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">3
+                      Linear Feet</extent><extent altrender="carrier">in 24 record cartons, 1
+                      manuscript box, and 1 flat file folder</extent><physfacet>This is still a
+                      test</physfacet><dimensions>2" x 2"</dimensions></physdesc>
+                  <unitdate normal="2020/2020" type="inclusive">2020</unitdate>
+                  <abstract id="aspace_bd177ed15d85410596d69971f1f80bed">Level 6 <emph
+                      render="italic">This is</emph> the <title>Abstract</title>. It has a <title
+                      render="bold" type="book" source="DACS">title</title> in it.</abstract>
+                  <materialspec id="aspace_d2c9a336620616b40793ea4442da9568">Level 6 This is the
+                    Materials Specific Details note.</materialspec>
+                  <physdesc id="aspace_f0aab22480ef05ebd2cac7af9d04f144"
+                    label="Physical Description">Level 6 This is the Physical Description
+                    note.</physdesc>
+                  <physloc id="aspace_3a86739f4caef7657334864aa471d4bc">Level 6 This is the Physical
+                    Location note.</physloc>
+                  <physloc id="aspace_1047114795bc03618b1e86e35a46e633">Box 152</physloc>
+                  <langmaterial id="aspace_ef9750889531488bd00e1945167928ff">Level 6 <emph
+                      render="italic">Materials</emph> in
+                    <language>English</language>.</langmaterial>
+                  <container altrender="Record carton" id="aspace_f3ec638b34e24bb929d32bde20342408"
+                    label="mixed materials" type="box">1</container>
+                  <container id="aspace_a529bf4b1240ae1fda32f6ece2151c2a"
+                    parent="aspace_f3ec638b34e24bb929d32bde20342408" type="folder">337</container>
+                  <daogrp xlink:title="Archived website of Julie Kathryn" xlink:type="extended">
+                    <daodesc>
+                      <p>Archived website of Julie Kathryn</p>
+                    </daodesc>
+                    <daoloc
+                      xlink:href="https://wayback.archive-it.org/9900/*/http://www.iamsnowangel.com"
+                      xlink:role="external-link" xlink:title="Archived website of Julie Kathryn"
+                      xlink:type="locator"/>
+                    <daoloc
+                      xlink:href="https://wayback.archive-it.org/4049/*/http://www.iamsnowangel.com"
+                      xlink:role="external-link" xlink:title="Archived website of Julie Kathryn"
+                      xlink:type="locator"/>
+                  </daogrp>
+                  <dao xlink:actuate="onRequest" xlink:href="https://hdl.handle.net/2333.1/zpc86f31"
+                    xlink:role="audio-service" xlink:show="new"
+                    xlink:title="This is a digital object" xlink:type="simple">
+                    <daodesc>
+                      <p>This is a digital object</p>
+                    </daodesc>
+                  </dao>
+                </did>
+                <accessrestrict id="aspace_c9c03fa497782d65588b32274d164303">
+                  <head>Conditions Governing <emph render="bold">Access</emph><extptr
+                      xlink:href="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                      xlink:show="new"
+                      xlink:title="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                      xlink:type="simple"/></head>
+                  <p>Level 6 This is the Conditions Governing Access note.</p>
+                </accessrestrict>
+                <accruals id="aspace_0d368dc1dfffb6a542b123463ad1cc12">
+                  <head>Accruals</head>
+                  <p>Level 6 This is the Accruals note.</p>
+                </accruals>
+                <acqinfo id="aspace_5ca40199efdfd5733e04514efb2b6193">
+                  <head>Immediate Source of Acquisition</head>
+                  <p>Level 6 This is the Immediate Source of Acquisition note.</p>
+                </acqinfo>
+                <appraisal id="aspace_f1719155533e992df4b8dedb738079c4">
+                  <head>Appraisal</head>
+                  <p>Level 6 This is the Appraisal note.</p>
+                </appraisal>
+                <arrangement id="aspace_0e4ee4b182cdc15829ffb21d9a19c71d">
+                  <head>Arrangement</head>
+                  <p>Level 6 This is the Arrangement note.</p>
+                </arrangement>
+                <bioghist id="aspace_da532e9ab91b1c4efe04248ae947c2ce">
+                  <head>Biographical note</head>
+                  <p>Level 6 This is the Biographical note.</p>
+                </bioghist>
+                <custodhist id="aspace_9f1cd52965c381e1f739ae9284e4284f">
+                  <head>Custodial History</head>
+                  <p>Level 6 This is the Custodial History note.</p>
+                </custodhist>
+                <fileplan id="aspace_1fa91112393b5806698aa2119e6f9d0a">
+                  <head>File Plan</head>
+                  <p>Level 6 This is the File Plan.</p>
+                </fileplan>
+                <odd id="aspace_cae795bb275b4ac07bfa2a13b22d7e3e">
+                  <head>General</head>
+                  <p>This is the Level 6 General note. <address>
+                      <addressline>Elmer Holmes Bobst Library</addressline>
+                      <addressline>70 Washington Square South</addressline>
+                      <addressline>2nd Floor</addressline>
+                      <addressline>New York, NY 10012</addressline>
+                      <addressline>special.collections@nyu.edu</addressline>
+                      <addressline>URL: <extptr
+                          xlink:href="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                          xlink:show="new"
+                          xlink:title="http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/"
+                          xlink:type="simple"/></addressline>
+                    </address>
+                    <abbr expan="Autographed Letter Signed">ALS</abbr>
+                    <archref>
+                      <extref xlink:href="http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/"
+                        xlink:title="Sally Belfrage" xlink:type="simple" xlink:show="new">The Sally
+                        Belfrage Papers (TAM 189)</extref></archref>
+                    <bibref><emph render="bold">Ardouin, Charles Nicholas Celigny</emph>. <title
+                        render="italic">Essais sur l'histoire d'Haiti</title>. Port-au-Prince,
+                      1865.</bibref>
+                    <blockquote>
+                      <p>No doubt the estate has exerted a tremendous influence on the development
+                        of my character. One may walk for an hour without glimpsing another soul,
+                        which has taught me to love tranquility.</p>
+                    </blockquote><lb/>
+                    <corpname source="naf">Tamiment Library</corpname>
+                    <date type="creation">March 2021</date>
+                    <list type="deflist" numeration="arabic">
+                      <listhead>
+                        <head01>Abbreviation</head01>
+                        <head02>Expansion</head02>
+                      </listhead>
+                      <defitem>
+                        <label>MIT</label>
+                        <item>Massachusetts Institute of Technology</item>
+                      </defitem>
+                    </list>
+                    <genreform source="aat">Oral histories (literary works)</genreform>
+                    <name>Rolodex</name>
+                    <num type="collection">MOS.2021</num>
+                    <occupation source="lcsh">Fulbright scholars.</occupation>
+                    <subject source="lcsh">Irish American women -- History -- 19th
+                      century.</subject>
+                    <list type="deflist">
+                      <defitem>
+                        <label>MIT</label>
+                        <item>Massachusetts Institute of Technology</item>
+                      </defitem>
+                    </list>
+                    <genreform source="aat">Oral histories (literary works)</genreform>
+                    <name>Rolodex</name>
+                    <num type="collection">MOS.2021</num>
+                    <occupation source="lcsh">Fulbright scholars.</occupation>
+                    <subject source="lcsh">Irish American women -- History -- 19th
+                      century.</subject></p>
+                  <list type="deflist">
+                    <defitem>
+                      <label>MIT</label>
+                      <item>Massachusetts Institute of Technology</item>
+                    </defitem>
+                  </list>
+                  <p><genreform source="aat">Oral histories (literary works)</genreform>
+                    <name>Rolodex</name>
+                    <num type="collection">MOS.2021</num>
+                    <occupation source="lcsh">Fulbright scholars.</occupation>
+                    <subject source="lcsh">Irish American women -- History -- 19th
+                      century.</subject></p>
+                  <list type="deflist">
+                    <defitem>
+                      <label>MIT</label>
+                      <item>Massachusetts Institute of Technology</item>
+                    </defitem>
+                  </list>
+                  <p><genreform source="aat">Oral histories (literary works)</genreform>
+                    <name>Rolodex</name>
+                    <num type="collection">MOS.2021</num>
+                    <occupation source="lcsh">Fulbright scholars.</occupation>
+                    <subject source="lcsh">Irish American women -- History -- 19th
+                      century.</subject></p>
+                </odd>
+                <otherfindaid id="aspace_d86f0ee1ed926e5bda6df6a01fb50430">
+                  <head>Other Finding Aids</head>
+                  <p>Level 6 This is the Other Finding Aids note.</p>
+                </otherfindaid>
+                <originalsloc id="aspace_1a9c2d5fe06d96d4356d279fb2a55891">
+                  <head>Existence and Location of Originals</head>
+                  <p>Level 6 This is the Existence and Location of Originals note.</p>
+                </originalsloc>
+                <phystech id="aspace_c9b2395b099958c2c6a4e3a69dc6c9c2">
+                  <head>Physical Characteristics and Technical Requirements</head>
+                  <p>Level 6 This is the Physical Characteristics and Technical Requirements
+                    note.</p>
+                </phystech>
+                <prefercite id="aspace_e8c53e51987e5304ad271fa53751b542">
+                  <head>Preferred Citation</head>
+                  <p>Level 6 This is the Preferred Citation note.</p>
+                </prefercite>
+                <processinfo id="aspace_5beb9e56a51c1c7f68772189839b8562">
+                  <head>Processing Information</head>
+                  <p>Level 6 This is the Processing Information note.</p>
+                </processinfo>
+                <relatedmaterial id="aspace_de6b994fae38995b216e753422b786dd">
+                  <head>Related Materials</head>
+                  <p>Level 6 This is the Related Materials note.</p>
+                </relatedmaterial>
+                <scopecontent id="aspace_5bada5174e4c359d28a66bcae1732c40">
+                  <head>Scope and Contents</head>
+                  <p>Level 6 This is the Scope and Content note.</p>
+                </scopecontent>
+                <separatedmaterial id="aspace_f83456cccb935c9341a7c4c0bb7af5f6">
+                  <head>Separated Materials</head>
+                  <p>Level 6 This is the Separated Materials note. <archref><physloc>Box
+                        152</physloc></archref></p>
+                </separatedmaterial>
+                <userestrict id="aspace_4178d83cc644ca0b095ad5d7aefded35">
+                  <head>Conditions Governing Use</head>
+                  <p>Level 6 This is the Conditions Governing Use note.</p>
+                </userestrict>
+                <index id="aspace_4c1c070e35cc0cddc8b73080510ad71a">
+                  <head>Index head</head>
+                  <p>Level 6 This is the Index.</p>
+                  <indexentry>
+                    <corpname>Level 6 Index item</corpname>
+                  </indexentry>
+                </index>
+                <controlaccess>
+                  <geogname source="lcsh">Boston (Mass.) -- Intellectual life -- 20th
+                    century.</geogname>
+                  <subject source="lcsh">Irish American women -- History -- 19th century.</subject>
+                  <genreform source="aat">Oral histories (literary works)</genreform>
+                  <occupation source="lcsh">Fulbright scholars.</occupation>
+                  <function source="local">War Powers Conference</function>
+                  <corpname source="naf">Tamiment Library</corpname>
+                  <famname rules="dacs" source="local">Belfrage family</famname>
+                </controlaccess>
+                <c id="aspace_71626d77bd977b19462b7319b0d4a5fb" level="file">
+                  <did>
+                    <unittitle>A File Nested Within a File, No Container</unittitle>
+                    <unitdate normal="1981-08-31/1981-08-31">1981-08-31</unitdate>
+                  </did>
+                </c>
+              </c>
+            </c>
+          </c>
+        </c>
+        <c id="aspace_b3c9c88449f4f8e8a4bf801cf619517b" level="item">
+          <did>
+            <unittitle><emph render="bold">This is an item</emph> Here is a <title>title</title>.
+              There is also a <name>name</name>.</unittitle>
+            <physloc id="aspace_a1505cc79395c354f713ced482260ea0">Box 152</physloc>
+            <physloc id="aspace_68b441337b28f7782012a4e85066959d">Box 152</physloc>
+            <physloc id="aspace_84f90467828627064ca55ffc7f1e8336">Box 152</physloc>
+            <container altrender="Record carton" id="aspace_aaeb8f9710e138489515eea6a13b5e2a"
+              label="mixed materials" type="box">1</container>
+            <dao xlink:actuate="onRequest"
+              xlink:href="https://aeon.library.nyu.edu/remoteauth/aeon.dll?Logon&amp;Action=10&amp;Form=31&amp;Value=http://dlib.nyu.edu/findingaids/ead/tamwag/mos_2021.xml&amp;view=xml"
+              xlink:role="electronic-records-service" xlink:show="new"
+              xlink:title="This is a digital object" xlink:type="simple">
+              <daodesc>
+                <p>This is a digital object</p>
+              </daodesc>
+            </dao>
+            <daogrp xlink:title="Archived website of Julie Kathryn" xlink:type="extended">
+              <daodesc>
+                <p>Archived website of Julie Kathryn</p>
+              </daodesc>
+              <daoloc xlink:href="https://wayback.archive-it.org/9900/*/http://www.iamsnowangel.com"
+                xlink:role="external-link" xlink:title="Archived website of Julie Kathryn"
+                xlink:type="locator"/>
+              <daoloc xlink:href="https://wayback.archive-it.org/4049/*/http://www.iamsnowangel.com"
+                xlink:role="external-link" xlink:title="Archived website of Julie Kathryn"
+                xlink:type="locator"/>
+            </daogrp>
+          </did>
+          <separatedmaterial id="aspace_00dd4ebd926cd579f1fd8739f3f4ac5b">
+            <head>Separated Materials</head>
+            <p><archref><physloc>Box 152</physloc></archref></p>
+          </separatedmaterial>
+          <bibliography id="aspace_dc8a27e3beef885bc858b1f2f7527e07">
+            <head>Bibliography</head>
+            <p><bibref>
+                <emph render="italic">This is Not It: Stories</emph> . New York: Distributed Art
+                Publishers, 2002. </bibref></p>
+            <bibref><emph render="italic">This is Not It: Stories</emph> . New York: Distributed Art
+              Publishers, 2002.</bibref>
+            <bibref><emph render="italic">This is Not It: Stories</emph> . New York: Distributed Art
+              Publishers, 2002.</bibref>
+            <bibref><emph render="italic">This is Not It: Stories</emph> . New York: Distributed Art
+              Publishers, 2002.</bibref>
+          </bibliography>
+        </c>
+        <c id="aspace_319857d7c2d36228d3335abb88396b2b" level="otherlevel" otherlevel="website">
+          <did>
+            <unittitle>The Dreaded Other Level</unittitle>
+            <unitdate normal="1981-09-02/1981-09-02">1981-09-02</unitdate>
+            <daogrp xlink:title="Archived website of Julie Kathryn" xlink:type="extended">
+              <daodesc>
+                <p>Archived website of Julie Kathryn</p>
+              </daodesc>
+              <daoloc xlink:href="https://wayback.archive-it.org/9900/*/http://www.iamsnowangel.com"
+                xlink:role="external-link" xlink:title="Archived website of Julie Kathryn"
+                xlink:type="locator"/>
+              <daoloc xlink:href="https://wayback.archive-it.org/4049/*/http://www.iamsnowangel.com"
+                xlink:role="external-link" xlink:title="Archived website of Julie Kathryn"
+                xlink:type="locator"/>
+            </daogrp>
+          </did>
+        </c>
+      </c>
+      <c id="additional-daos" level="series">
+        <did>
+          <unittitle>Series II. Additional Digital Objects</unittitle>
+        </did>
+        <c id="dao1" level="file">
+          <did>
+            <unittitle>Audio-Service</unittitle>
+            <dao xlink:actuate="onRequest" xlink:href="https://hdl.handle.net/2333.1/wm37q0k4"
+              xlink:role="audio-service" xlink:show="new"
+              xlink:title="4th Annual Flaherty Seminar - Tape 1" xlink:type="simple">
+              <daodesc>
+                <p>4th Annual Flaherty Seminar - Tape 1: August 19, 1958</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="dao2" level="file">
+          <did>
+            <unittitle>Audio-Reading-Room</unittitle>
+            <dao xlink:actuate="onLoad"
+              xlink:href="https://aeon.library.nyu.edu/Logon?Action=10&amp;Form=31&amp;Value=http://dlib.nyu.edu/findingaids/ead/fales/mss_094.xml&amp;view=xml"
+              xlink:role="audio-reading-room" xlink:show="new"
+              xlink:title="Cassettes - America's Disinherited - Commentary by Hacker/Willens -4/14/85"
+              xlink:type="simple">
+              <daodesc>
+                <p>Cassettes - America's Disinherited - Commentary by Hacker/Willens -4/14/85</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="dao3" level="file">
+          <did>
+            <unittitle>Video-Service</unittitle>
+            <dao xlink:actuate="onRequest" xlink:href="https://hdl.handle.net/2333.1/bnzs7m9t"
+              xlink:role="video-service" xlink:show="new"
+              xlink:title="[1]--Gay USA, Vol. [VIII] Episode No. 4 [Air date: 7/19/1990]"
+              xlink:type="simple">
+              <daodesc>
+                <p>[1]--Gay USA, Vol. [VIII] Episode No. 4 [Air date: 7/19/1990]: July 1990</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="dao4" level="file">
+          <did>
+            <unittitle>Video-Reading-Room</unittitle>
+            <dao xlink:actuate="onLoad"
+              xlink:href="https://aeon.library.nyu.edu/Logon?Action=10&amp;Form=31&amp;Value=http://dlib.nyu.edu/findingaids/ead/fales/mss_276.xml&amp;view=xml"
+              xlink:role="video-reading-room" xlink:show="new"
+              xlink:title="Herb KO's Corporate Sports - Dub Master" xlink:type="simple">
+              <daodesc>
+                <p>Herb KO's Corporate Sports - Dub Master</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="dao5" level="file">
+          <did>
+            <unittitle>Image-Service</unittitle>
+            <dao xlink:actuate="onRequest" xlink:href="https://hdl.handle.net/2333.1/ttdz0j92"
+              xlink:role="image-service" xlink:show="new"
+              xlink:title="Envelope 1: Caven Point, NJ, 1984 w/Steve Brown" xlink:type="simple">
+              <daodesc>
+                <p>Envelope 1: Caven Point, NJ, 1984 w/Steve Brown: undated</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="dao6" level="file">
+          <did>
+            <unittitle>External-Link</unittitle>
+            <dao xlink:actuate="onLoad"
+              xlink:href="https://wayback.archive-it.org/6129/*/http://www.thefugs.com/"
+              xlink:role="external-link" xlink:show="new" xlink:title="Archived website of the Fugs"
+              xlink:type="simple">
+              <daodesc>
+                <p>Archived website of the Fugs</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="dao7" level="file">
+          <did>
+            <unittitle>Electronic-Records-Reading-Room</unittitle>
+            <dao xlink:actuate="onLoad"
+              xlink:href="https://aeon.library.nyu.edu/Logon?Action=10&amp;Form=31&amp;Value=%20http://dlib.nyu.edu/findingaids/ead/fales/mss_253.xml&amp;view=xml"
+              xlink:role="electronic-records-reading-room" xlink:show="new"
+              xlink:title="Digital Duets Langland La MaMa" xlink:type="simple">
+              <daodesc>
+                <p>Digital Duets Langland La MaMa: 2012-</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_7c4d41e52826eec1ee0f21625ae73961" level="file">
+          <did>
+            <unittitle>Image-Service</unittitle>
+            <dao xlink:actuate="onRequest" xlink:href="https://hdl.handle.net/2333.1/dfn2z8sk"
+              xlink:role="image-service" xlink:show="new"
+              xlink:title="Three children in the Japanese Gardens: 1984" xlink:type="simple">
+              <daodesc>
+                <p>Three children in the Japanese Gardens: 1984</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+      </c>
+    </dsc>
+  </archdesc>
+</ead>

--- a/ead/testdata/tamwag/mos_2021.json
+++ b/ead/testdata/tamwag/mos_2021.json
@@ -1,0 +1,5084 @@
+{
+    "runinfo": {
+        "libversion": "",
+        "timestamp": "0001-01-01T00:00:00Z",
+        "sourcefile": ""
+    },
+    "pubinfo": {
+        "themeid": "",
+        "reposidentifier": ""
+    },
+    "archdesc": {
+        "level": "collection",
+        "accessrestrict": [
+            {
+                "id": "aspace_7737a7dc7fd92d0055945aaca8066375",
+                "head": {
+                    "value": "Conditions Governing Access"
+                },
+                "children": [
+                    {
+                        "name": "legalstatus",
+                        "value": {
+                            "value": "This is the Conditions Governing Access note.",
+                            "id": "whatever"
+                        }
+                    },
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "\u003cspan class=\"ead-chronlist\"\u003e \u003cspan class=\"ead-head\"\u003eThe following chronology provides a backdrop for the Board of Higher Education of the City of New York cases included within this collection:\u003c/span\u003e \u003cspan class=\"ead-chronitem\"\u003e \u003cspan class=\"ead-date\"\u003e1939\u003c/span\u003e \u003cspan class=\"ead-eventgrp\"\u003e \u003cspan class=\"ead-event\"\u003eThe \u003cspan class=\"ead-emph ead-emph-italic\"\u003eNew York State Legislature\u003c/span\u003e enacted Section 12-a of the \u003cspan class=\"ead-title\"\u003eCivil Service Law\u003c/span\u003e which provided in substance that \"no person shall be appointed to or retained in the public service nor in any public educational institution who becomes a member of any organization which advocates the overthrow of government by force or violence, or by any unlawful means (L. 1939, Ch. 547).\"\u003c/span\u003e \u003c/span\u003e \u003c/span\u003e \u003c/span\u003e",
+                            "chronlist": [
+                                {
+                                    "head": {
+                                        "value": "The following chronology provides a backdrop for the Board of Higher Education of the City of New York cases included within this collection:"
+                                    },
+                                    "chronitem": [
+                                        {
+                                            "value": "\u003cspan class=\"ead-date\"\u003e1939\u003c/span\u003e \u003cspan class=\"ead-eventgrp\"\u003e \u003cspan class=\"ead-event\"\u003eThe \u003cspan class=\"ead-emph ead-emph-italic\"\u003eNew York State Legislature\u003c/span\u003e enacted Section 12-a of the \u003cspan class=\"ead-title\"\u003eCivil Service Law\u003c/span\u003e which provided in substance that \"no person shall be appointed to or retained in the public service nor in any public educational institution who becomes a member of any organization which advocates the overthrow of government by force or violence, or by any unlawful means (L. 1939, Ch. 547).\"\u003c/span\u003e \u003c/span\u003e",
+                                            "date": [
+                                                {
+                                                    "value": "1939"
+                                                }
+                                            ],
+                                            "eventgrp": [
+                                                {
+                                                    "event": [
+                                                        {
+                                                            "value": "The \u003cspan class=\"ead-emph ead-emph-italic\"\u003eNew York State Legislature\u003c/span\u003e enacted Section 12-a of the \u003cspan class=\"ead-title\"\u003eCivil Service Law\u003c/span\u003e which provided in substance that \"no person shall be appointed to or retained in the public service nor in any public educational institution who becomes a member of any organization which advocates the overthrow of government by force or violence, or by any unlawful means (L. 1939, Ch. 547).\"",
+                                                            "title": [
+                                                                {
+                                                                    "value": "Civil Service Law"
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "\u003cspan class=\"ead-list\"\u003e \u003cspan class=\"ead-listhead\"\u003e \u003cspan class=\"ead-head01\"\u003eAbbreviation\u003c/span\u003e \u003cspan class=\"ead-head02\"\u003eExpansion\u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-defitem\"\u003e \u003cspan class=\"ead-label\"\u003eMIT\u003c/span\u003e \u003cspan class=\"ead-item\"\u003eMassachusetts Institute of Technology\u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-defitem\"\u003e \u003cspan class=\"ead-label\"\u003ePCV\u003c/span\u003e \u003cspan class=\"ead-item\"\u003ePeace Corps Volunteer\u003c/span\u003e \u003c/span\u003e \u003c/span\u003e",
+                            "list": [
+                                {
+                                    "type": "deflist",
+                                    "defitem": [
+                                        {
+                                            "item": [
+                                                {
+                                                    "value": "Massachusetts Institute of Technology"
+                                                }
+                                            ],
+                                            "label": "MIT"
+                                        },
+                                        {
+                                            "item": [
+                                                {
+                                                    "value": "Peace Corps Volunteer"
+                                                }
+                                            ],
+                                            "label": "PCV"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "list",
+                        "value": {
+                            "numeration": "arabic",
+                            "type": "ordered",
+                            "head": {
+                                "value": "Ordered List"
+                            },
+                            "item": [
+                                {
+                                    "value": "\u003cspan class=\"ead-bibref\"\u003eThis is a citation for \u003cspan class=\"ead-persname\"\u003eWeatherly Stephan\u003c/span\u003e's \u003cspan class=\"ead-title\"\u003eJournal of Archival Organization\u003c/span\u003e article.\u003c/span\u003e",
+                                    "bibref": [
+                                        {
+                                            "value": "This is a citation for \u003cspan class=\"ead-persname\"\u003eWeatherly Stephan\u003c/span\u003e's \u003cspan class=\"ead-title\"\u003eJournal of Archival Organization\u003c/span\u003e article.",
+                                            "title": [
+                                                {
+                                                    "value": "Journal of Archival Organization"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "value": "I don't know why on earth you'd put a \u003cspan class=\"ead-emph ead-emph-bold\"\u003eline break\u003c/span\u003e in an ordered list, \u003cbr\u003e but here ya go."
+                                },
+                                {
+                                    "value": "Copyright \u003cspan class=\"ead-corpname\"\u003eNew York University\u003c/span\u003e, all rights reserved.",
+                                    "corpname": [
+                                        {
+                                            "value": "New York University"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "value": "This is just a \u003cspan class=\"ead-name\"\u003ename\u003c/span\u003e name with no identity.",
+                                    "name": [
+                                        {
+                                            "value": "name"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ],
+        "accruals": [
+            {
+                "id": "aspace_f05011cc547339bd4114711751029c6d",
+                "head": {
+                    "value": "Accruals \u003cspan class=\"ead-emph ead-emph-bold\"\u003eNote\u003c/span\u003e"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the Accruals note."
+                        }
+                    }
+                ]
+            }
+        ],
+        "acqinfo": [
+            {
+                "id": "aspace_7be31470c64f6cfbf4336ba9af1a31d3",
+                "head": {
+                    "value": "Immediate Source of Acquisition"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the Immediate Source of Acquisition note."
+                        }
+                    }
+                ]
+            }
+        ],
+        "altformavail": [
+            {
+                "id": "aspace_3c14dd8815fd455800c71570138316c6",
+                "head": {
+                    "value": "Existence and Location of Copies"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the Existence and Location of Copies note."
+                        }
+                    }
+                ]
+            }
+        ],
+        "appraisal": [
+            {
+                "id": "aspace_45cf36d965d0f038d67621dbebb9ebf1",
+                "head": {
+                    "value": "Appraisal"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the Appraisal note."
+                        }
+                    }
+                ]
+            }
+        ],
+        "arrangement": [
+            {
+                "id": "aspace_65d23a620677d7f70a9b3dcfa9523829",
+                "head": {
+                    "value": "Arrangement"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the Arrangement note."
+                        }
+                    }
+                ]
+            }
+        ],
+        "bibliography": [
+            {
+                "id": "aspace_4eace9a22f9f43be89b214957dbba587",
+                "head": {
+                    "value": "Bibliography"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the Bibliography."
+                        }
+                    },
+                    {
+                        "name": "bibref",
+                        "value": {
+                            "value": "Adler, Jerry. \u003cspan class=\"ead-title\"\u003eHigh \u003cspan class=\"ead-emph ead-emph-italic\"\u003eRise\u003c/span\u003e.\u003c/span\u003eNew York: \u003cbr\u003e \u003cspan class=\"ead-corpname\"\u003eHarper Collins,\u003c/span\u003e 1993.",
+                            "title": [
+                                {
+                                    "value": "High \u003cspan class=\"ead-emph ead-emph-italic\"\u003eRise\u003c/span\u003e."
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "bibref",
+                        "value": {
+                            "value": "Corruption and Racketeering in the \u003cspan class=\"ead-name\"\u003eNew York City\u003c/span\u003e Construction Industry. Interim Report by the New York State Organized Crime Task Force. Ithaca, NY: ILR Press, New York State School of Industrial and Labor Relations, Cornell University, 1988."
+                        }
+                    },
+                    {
+                        "name": "bibref",
+                        "value": {
+                            "value": "Corruption and Racketeering in the New York City Construction Industry. Final Report to \u003cspan class=\"ead-persname\"\u003eGovernor Mario M. Cuomo\u003c/span\u003e. Ronald Goldstock, Director, New York State Organized Crime Task Force. December 1989."
+                        }
+                    },
+                    {
+                        "name": "bibref",
+                        "value": {
+                            "value": "\u003cspan class=\"ead-emph ead-emph-bold\"\u003eArdouin, Charles Nicholas Celigny\u003c/span\u003e. \u003cspan class=\"ead-title\"\u003eEssais sur l'histoire d'Haiti\u003c/span\u003e. Port-au-Prince, 1865.",
+                            "title": [
+                                {
+                                    "value": "Essais sur l'histoire d'Haiti",
+                                    "render": "italic"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ],
+        "bioghist": [
+            {
+                "id": "aspace_5bfa9f2060a4b600e0b0ae6c3924354b",
+                "head": {
+                    "value": "Biographical Note"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the Biographical note."
+                        }
+                    }
+                ]
+            }
+        ],
+        "controlaccess": [
+            {
+                "corpname": [
+                    {
+                        "role": "Donor",
+                        "value": "Tamiment Library"
+                    }
+                ],
+                "function": [
+                    {
+                        "value": "War Powers Conference"
+                    }
+                ],
+                "genreform": [
+                    {
+                        "value": "Oral histories (literary works)"
+                    }
+                ],
+                "geogname": [
+                    {
+                        "value": "Boston (Mass.) -- Intellectual life -- 20th century."
+                    }
+                ],
+                "occupation": [
+                    {
+                        "value": "Fulbright scholars."
+                    }
+                ],
+                "persname": [
+                    {
+                        "role": "Donor",
+                        "value": "Debs, Eugene V. (Eugene Victor), 1855-1926"
+                    }
+                ],
+                "subject": [
+                    {
+                        "value": "Irish American women -- History -- 19th century."
+                    }
+                ],
+                "title": [
+                    {
+                        "value": "New York Nichibei.",
+                        "source": "local"
+                    }
+                ]
+            }
+        ],
+        "custodhist": [
+            {
+                "id": "aspace_03c962dea0c06463b3615c01bc8ac97e",
+                "head": {
+                    "value": "Custodial History"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the Custodial History note."
+                        }
+                    }
+                ]
+            }
+        ],
+        "did": {
+            "physdesc": [
+                {
+                    "value": "\u003cspan class=\"ead-extent\"\u003e25 Linear Feet\u003c/span\u003e \u003cspan class=\"ead-extent\"\u003ein \u003cspan class=\"ead-emph ead-emph-bold\"\u003e24 record cartons\u003c/span\u003e, \u003cbr\u003e1 manuscript box, and 1 flat file folder\u003c/span\u003e \u003cspan class=\"ead-dimensions\"\u003e\u003cspan class=\"ead-dimensions\"\u003e24\" x 24\"\u003c/span\u003e\u003c/span\u003e",
+                    "altrender": "whole",
+                    "extent": [
+                        {
+                            "value": "25 Linear Feet",
+                            "altrender": "materialtype spaceoccupied"
+                        },
+                        {
+                            "value": "in \u003cspan class=\"ead-emph ead-emph-bold\"\u003e24 record cartons\u003c/span\u003e, \u003cbr\u003e1 manuscript box, and 1 flat file folder",
+                            "altrender": "carrier"
+                        }
+                    ],
+                    "dimensions": {
+                        "value": "\u003cspan class=\"ead-dimensions\"\u003e24\" x 24\"\u003c/span\u003e"
+                    }
+                },
+                {
+                    "value": "\u003cspan class=\"ead-physfacet\"\u003eThis is the \u003cspan class=\"ead-emph ead-emph-italic\"\u003ephysical facet\u003c/span\u003e of the collection.\u003c/span\u003e",
+                    "physfacet": {
+                        "value": "This is the \u003cspan class=\"ead-emph ead-emph-italic\"\u003ephysical facet\u003c/span\u003e of the collection.",
+                        "id": "aspace_22323",
+                        "label": "Physical Facets Are Important"
+                    }
+                },
+                {
+                    "value": "\u003cspan class=\"ead-extent\"\u003e10 folders\u003c/span\u003e",
+                    "id": "aspace_29d371fa27aa7ebbde64468e06791bbc",
+                    "extent": [
+                        {
+                            "value": "10 folders",
+                            "unit": "folders"
+                        }
+                    ]
+                }
+            ],
+            "abstract": [
+                {
+                    "value": "This is the \u003cspan class=\"ead-emph ead-emph-italic\"\u003eabstract\u003c/span\u003e.\u003cbr\u003e It has a \u003cspan class=\"ead-title\"\u003etitle\u003c/span\u003e in it.",
+                    "id": "aspace_ref3",
+                    "title": [
+                        {
+                            "value": "title"
+                        }
+                    ]
+                }
+            ],
+            "langmaterial": [
+                {
+                    "value": "\u003cspan class=\"ead-emph ead-emph-\"\u003eEnglish is the language\u003c/span\u003e",
+                    "id": "aspace_791d685c5b2d2cc8c7d9d982ed6d5dee"
+                }
+            ],
+            "origination": [
+                {
+                    "label": "Creator",
+                    "persname": [
+                        {
+                            "role": "Donor",
+                            "value": "Megan O'Shea"
+                        }
+                    ]
+                },
+                {
+                    "label": "source",
+                    "persname": [
+                        {
+                            "role": "Donor",
+                            "value": "Debs, Eugene V. (Eugene Victor), 1855-1926"
+                        }
+                    ]
+                },
+                {
+                    "label": "Creator",
+                    "famname": [
+                        {
+                            "role": "Donor",
+                            "value": "Belfrage family"
+                        }
+                    ]
+                },
+                {
+                    "label": "source",
+                    "corpname": [
+                        {
+                            "role": "Donor",
+                            "value": "Tamiment Library"
+                        }
+                    ]
+                },
+                {
+                    "label": "Creator",
+                    "persname": [
+                        {
+                            "value": "Weatherly Stephan"
+                        }
+                    ]
+                }
+            ],
+            "repository": {
+                "value": "\u003cspan class=\"ead-corpname\"\u003eTamiment Library and Robert F. Wagner Labor Archives\u003c/span\u003e",
+                "corpname": [
+                    {
+                        "value": "Tamiment Library and Robert F. Wagner Labor Archives"
+                    }
+                ]
+            },
+            "unitdate": [
+                {
+                    "value": "2016-2021, undated",
+                    "type": "inclusive",
+                    "normal": "2016/2021"
+                },
+                {
+                    "value": "circa 1910",
+                    "type": "inclusive",
+                    "normal": "1910/1910"
+                },
+                {
+                    "value": "1977-2000",
+                    "type": "inclusive",
+                    "normal": "1977/2000"
+                },
+                {
+                    "value": "2013",
+                    "datechar": "digitized",
+                    "normal": "2013/2013"
+                },
+                {},
+                {
+                    "value": "1914-2014",
+                    "datechar": "digitized",
+                    "normal": "1914/2014"
+                },
+                {
+                    "value": "2018-02-08",
+                    "datechar": "digitized",
+                    "normal": "2018-02-08/2018-02-08"
+                }
+            ],
+            "unitid": "MOS.2021",
+            "unittitle": {
+                "value": "Megan O'Shea's One Resource to Rule Them All"
+            }
+        },
+        "dsc": {
+            "c": [
+                {
+                    "id": "aspace_499449c48c751a22b7c222d3ce2c2879",
+                    "level": "series",
+                    "accessrestrict": [
+                        {
+                            "id": "aspace_ec2c2285331d2824ae8d4c21e73a552f",
+                            "head": {
+                                "value": "Conditions Governing \u003cspan class=\"ead-emph ead-emph-bold\"\u003eAccess\u003c/span\u003e\u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "Level 2 This is the Conditions Governing Access note."
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "accruals": [
+                        {
+                            "id": "aspace_19f4f59324d4ae62b7ef7e56745039f8",
+                            "head": {
+                                "value": "Accruals"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "Level 2 This is the Accruals note."
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "acqinfo": [
+                        {
+                            "id": "aspace_fe2d05d0c6ece43176098328e53f4aa7",
+                            "head": {
+                                "value": "Immediate Source of Acquisition"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "Level 2 This is the Immediate Source of Acquisition note."
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "appraisal": [
+                        {
+                            "id": "aspace_03db3d0296470cb21020f2882c24bd68",
+                            "head": {
+                                "value": "Appraisal"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "Level 2 This is the Appraisal note."
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "arrangement": [
+                        {
+                            "id": "aspace_cfbd8ed70f80e9c46e47361081f34805",
+                            "head": {
+                                "value": "Arrangement"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "Level 2 This is the Arrangement note."
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "bioghist": [
+                        {
+                            "id": "aspace_c3b852caca83ed640a525cc9c12c1230",
+                            "head": {
+                                "value": "Historical Note"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "Level 2 This is the Historical note."
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "c": [
+                        {
+                            "id": "aspace_68fd22d28746c12f37e250728431c61d",
+                            "level": "subseries",
+                            "accessrestrict": [
+                                {
+                                    "id": "aspace_818a64a65aec3301db238f513d232538",
+                                    "head": {
+                                        "value": "Conditions Governing \u003cspan class=\"ead-emph ead-emph-bold\"\u003eAccess\u003c/span\u003e\u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "Level 3 This is the Conditions Governing Access note."
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "accruals": [
+                                {
+                                    "id": "aspace_24307e8faf8521203474d580d126ab79",
+                                    "head": {
+                                        "value": "Accruals"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "Level 3 This is the Accruals note."
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "acqinfo": [
+                                {
+                                    "id": "aspace_8b2c6d8b5a9b524962773d44488b0724",
+                                    "head": {
+                                        "value": "Immediate Source of Acquisition"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "Level 3 This is the Immediate Source of Acquisition note."
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "appraisal": [
+                                {
+                                    "id": "aspace_5af491aeee5421d484748713f0d21e07",
+                                    "head": {
+                                        "value": "Appraisal"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "Level 3 This is the Appraisal note."
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "arrangement": [
+                                {
+                                    "id": "aspace_3e705b21424f2473489b1aba513c8701",
+                                    "head": {
+                                        "value": "Arrangement"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "Level 3 This is the Arrangement note."
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "bioghist": [
+                                {
+                                    "id": "aspace_44878fdbd29194369fed682088365a06",
+                                    "head": {
+                                        "value": "Biographical note"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "Level 3 This is the Biographical note."
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "c": [
+                                {
+                                    "id": "aspace_f35efa0f6a068b57a2d396067e4f7427",
+                                    "level": "subseries",
+                                    "accessrestrict": [
+                                        {
+                                            "id": "aspace_a6d071b6ad4eb8400fc708ab7e393136",
+                                            "head": {
+                                                "value": "Conditions Governing \u003cspan class=\"ead-emph ead-emph-bold\"\u003eAccess\u003c/span\u003e\u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "Level 4 This is the Conditions Governing Access note."
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "accruals": [
+                                        {
+                                            "id": "aspace_b563af80b992113e66b83b7467357813",
+                                            "head": {
+                                                "value": "Accruals"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "Level 4 This is the Accruals note."
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "acqinfo": [
+                                        {
+                                            "id": "aspace_12a46dab225b86dac76a34817cd9be6a",
+                                            "head": {
+                                                "value": "Immediate Source of Acquisition"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "Level 4 This is the Immediate Source of Acquisition note."
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "appraisal": [
+                                        {
+                                            "id": "aspace_e40cf639d4a8e85ae1da694532c4d750",
+                                            "head": {
+                                                "value": "Appraisal"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "Level 4 This is the Appraisal note."
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "arrangement": [
+                                        {
+                                            "id": "aspace_bc17a8237c1f92971b51dca841d298be",
+                                            "head": {
+                                                "value": "Arrangement"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "Level 4 This is the Arrangement note."
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "bioghist": [
+                                        {
+                                            "id": "aspace_cab5bf3424cb6a76e09f80c5d02d322c",
+                                            "head": {
+                                                "value": "Biographical note"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "Level 4 This is the Biographical note."
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "c": [
+                                        {
+                                            "id": "aspace_a8e8b321d84febb7aee747f54e624fc4",
+                                            "level": "subseries",
+                                            "accessrestrict": [
+                                                {
+                                                    "id": "aspace_346f8529644844c23c573252cfddf5c6",
+                                                    "head": {
+                                                        "value": "Conditions Governing \u003cspan class=\"ead-emph ead-emph-bold\"\u003eAccess\u003c/span\u003e\u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "Level 5 This is the Conditions Governing Access note."
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "accruals": [
+                                                {
+                                                    "id": "aspace_c6d0b18bc1ed738be695d4c2de144f1a",
+                                                    "head": {
+                                                        "value": "Accruals"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "Level 5 This is the Accruals note."
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "acqinfo": [
+                                                {
+                                                    "id": "aspace_5166484a658f95efdab1b8f8ec7f0e40",
+                                                    "head": {
+                                                        "value": "Immediate Source of Acquisition"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "Level 5 This is the Immediate Source of Acquisition note."
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "appraisal": [
+                                                {
+                                                    "id": "aspace_15fe109c0bd60dbaf1eff70fa2c4d25e",
+                                                    "head": {
+                                                        "value": "Appraisal"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "Level 5 This is the Appraisal note."
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "arrangement": [
+                                                {
+                                                    "id": "aspace_a263870a70533b6b5b78051352ba3315",
+                                                    "head": {
+                                                        "value": "Arrangement"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "Level 5 This is the Arrangement note."
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "bioghist": [
+                                                {
+                                                    "id": "aspace_b615c8b6866a3abc8c6aebe0f2307689",
+                                                    "head": {
+                                                        "value": "Biographical note"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "Level 5 This is the Biographical note."
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "c": [
+                                                {
+                                                    "id": "aspace_bb018068fcbef8e42d90b29434d476d6",
+                                                    "level": "file",
+                                                    "accessrestrict": [
+                                                        {
+                                                            "id": "aspace_c9c03fa497782d65588b32274d164303",
+                                                            "head": {
+                                                                "value": "Conditions Governing \u003cspan class=\"ead-emph ead-emph-bold\"\u003eAccess\u003c/span\u003e\u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "Level 6 This is the Conditions Governing Access note."
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "accruals": [
+                                                        {
+                                                            "id": "aspace_0d368dc1dfffb6a542b123463ad1cc12",
+                                                            "head": {
+                                                                "value": "Accruals"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "Level 6 This is the Accruals note."
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "acqinfo": [
+                                                        {
+                                                            "id": "aspace_5ca40199efdfd5733e04514efb2b6193",
+                                                            "head": {
+                                                                "value": "Immediate Source of Acquisition"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "Level 6 This is the Immediate Source of Acquisition note."
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "appraisal": [
+                                                        {
+                                                            "id": "aspace_f1719155533e992df4b8dedb738079c4",
+                                                            "head": {
+                                                                "value": "Appraisal"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "Level 6 This is the Appraisal note."
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "arrangement": [
+                                                        {
+                                                            "id": "aspace_0e4ee4b182cdc15829ffb21d9a19c71d",
+                                                            "head": {
+                                                                "value": "Arrangement"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "Level 6 This is the Arrangement note."
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "bioghist": [
+                                                        {
+                                                            "id": "aspace_da532e9ab91b1c4efe04248ae947c2ce",
+                                                            "head": {
+                                                                "value": "Biographical note"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "Level 6 This is the Biographical note."
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "c": [
+                                                        {
+                                                            "id": "aspace_71626d77bd977b19462b7319b0d4a5fb",
+                                                            "level": "file",
+                                                            "did": {
+                                                                "unitdate": [
+                                                                    {
+                                                                        "value": "1981-08-31",
+                                                                        "normal": "1981-08-31/1981-08-31"
+                                                                    }
+                                                                ],
+                                                                "unittitle": {
+                                                                    "value": "A File Nested Within a File, No Container"
+                                                                }
+                                                            }
+                                                        }
+                                                    ],
+                                                    "controlaccess": [
+                                                        {
+                                                            "corpname": [
+                                                                {
+                                                                    "value": "Tamiment Library"
+                                                                }
+                                                            ],
+                                                            "famname": [
+                                                                {
+                                                                    "value": "Belfrage family"
+                                                                }
+                                                            ],
+                                                            "function": [
+                                                                {
+                                                                    "value": "War Powers Conference"
+                                                                }
+                                                            ],
+                                                            "genreform": [
+                                                                {
+                                                                    "value": "Oral histories (literary works)"
+                                                                }
+                                                            ],
+                                                            "geogname": [
+                                                                {
+                                                                    "value": "Boston (Mass.) -- Intellectual life -- 20th century."
+                                                                }
+                                                            ],
+                                                            "occupation": [
+                                                                {
+                                                                    "value": "Fulbright scholars."
+                                                                }
+                                                            ],
+                                                            "subject": [
+                                                                {
+                                                                    "value": "Irish American women -- History -- 19th century."
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "custodhist": [
+                                                        {
+                                                            "id": "aspace_9f1cd52965c381e1f739ae9284e4284f",
+                                                            "head": {
+                                                                "value": "Custodial History"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "Level 6 This is the Custodial History note."
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "did": {
+                                                        "physdesc": [
+                                                            {
+                                                                "value": "\u003cspan class=\"ead-extent\"\u003e3 Linear Feet\u003c/span\u003e\u003cspan class=\"ead-extent\"\u003ein 24 record cartons, 1 manuscript box, and 1 flat file folder\u003c/span\u003e\u003cspan class=\"ead-physfacet\"\u003eThis is still a test\u003c/span\u003e\u003cspan class=\"ead-dimensions\"\u003e2\" x 2\"\u003c/span\u003e",
+                                                                "altrender": "whole",
+                                                                "extent": [
+                                                                    {
+                                                                        "value": "3 Linear Feet",
+                                                                        "altrender": "materialtype spaceoccupied"
+                                                                    },
+                                                                    {
+                                                                        "value": "in 24 record cartons, 1 manuscript box, and 1 flat file folder",
+                                                                        "altrender": "carrier"
+                                                                    }
+                                                                ],
+                                                                "dimensions": {
+                                                                    "value": "2\" x 2\""
+                                                                },
+                                                                "physfacet": {
+                                                                    "value": "This is still a test"
+                                                                }
+                                                            },
+                                                            {
+                                                                "value": "Level 6 This is the Physical Description note.",
+                                                                "id": "aspace_f0aab22480ef05ebd2cac7af9d04f144",
+                                                                "label": "Physical Description"
+                                                            }
+                                                        ],
+                                                        "abstract": [
+                                                            {
+                                                                "value": "Level 6 \u003cspan class=\"ead-emph ead-emph-italic\"\u003eThis is\u003c/span\u003e the \u003cspan class=\"ead-title\"\u003eAbstract\u003c/span\u003e. It has a \u003cspan class=\"ead-title\"\u003etitle\u003c/span\u003e in it.",
+                                                                "id": "aspace_bd177ed15d85410596d69971f1f80bed",
+                                                                "title": [
+                                                                    {
+                                                                        "value": "Abstract"
+                                                                    },
+                                                                    {
+                                                                        "value": "title",
+                                                                        "render": "bold",
+                                                                        "source": "DACS",
+                                                                        "type": "book"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ],
+                                                        "container": [
+                                                            {
+                                                                "value": "1",
+                                                                "altrender": "Record carton",
+                                                                "id": "aspace_f3ec638b34e24bb929d32bde20342408",
+                                                                "label": "mixed materials",
+                                                                "type": "box"
+                                                            },
+                                                            {
+                                                                "value": "337",
+                                                                "id": "aspace_a529bf4b1240ae1fda32f6ece2151c2a",
+                                                                "parent": "aspace_f3ec638b34e24bb929d32bde20342408",
+                                                                "type": "folder"
+                                                            }
+                                                        ],
+                                                        "dao": [
+                                                            {
+                                                                "actuate": "onRequest",
+                                                                "href": "https://hdl.handle.net/2333.1/zpc86f31",
+                                                                "role": "audio-service",
+                                                                "show": "new",
+                                                                "title": "This is a digital object",
+                                                                "type": "simple",
+                                                                "daodesc": {
+                                                                    "p": [
+                                                                        {
+                                                                            "value": "This is a digital object"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ],
+                                                        "daogrp": [
+                                                            {
+                                                                "title": "Archived website of Julie Kathryn",
+                                                                "type": "extended",
+                                                                "daodesc": {
+                                                                    "p": [
+                                                                        {
+                                                                            "value": "Archived website of Julie Kathryn"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "daoloc": [
+                                                                    {
+                                                                        "href": "https://wayback.archive-it.org/9900/*/http://www.iamsnowangel.com",
+                                                                        "role": "external-link",
+                                                                        "title": "Archived website of Julie Kathryn",
+                                                                        "type": "locator"
+                                                                    },
+                                                                    {
+                                                                        "href": "https://wayback.archive-it.org/4049/*/http://www.iamsnowangel.com",
+                                                                        "role": "external-link",
+                                                                        "title": "Archived website of Julie Kathryn",
+                                                                        "type": "locator"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ],
+                                                        "langmaterial": [
+                                                            {
+                                                                "value": "Level 6 \u003cspan class=\"ead-emph ead-emph-italic\"\u003eMaterials\u003c/span\u003e in \u003cspan class=\"ead-language\"\u003eEnglish\u003c/span\u003e.",
+                                                                "id": "aspace_ef9750889531488bd00e1945167928ff",
+                                                                "language": [
+                                                                    "English"
+                                                                ]
+                                                            }
+                                                        ],
+                                                        "materialspec": [
+                                                            {
+                                                                "id": "aspace_d2c9a336620616b40793ea4442da9568",
+                                                                "children": [
+                                                                    {
+                                                                        "name": "div",
+                                                                        "value": {
+                                                                            "value": "Level 6 This is the Materials Specific Details note."
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ],
+                                                        "origination": [
+                                                            {
+                                                                "label": "Creator",
+                                                                "corpname": [
+                                                                    {
+                                                                        "value": "Workers' Party of Ireland"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "label": "Creator",
+                                                                "famname": [
+                                                                    {
+                                                                        "value": "Blaustein Family"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "label": "Creator",
+                                                                "persname": [
+                                                                    {
+                                                                        "value": "Alum, Rolando A."
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ],
+                                                        "physloc": [
+                                                            {
+                                                                "value": "Level 6 This is the Physical Location note.",
+                                                                "id": "aspace_3a86739f4caef7657334864aa471d4bc"
+                                                            },
+                                                            {
+                                                                "value": "Box 152",
+                                                                "id": "aspace_1047114795bc03618b1e86e35a46e633"
+                                                            }
+                                                        ],
+                                                        "unitdate": [
+                                                            {
+                                                                "value": "2020",
+                                                                "type": "inclusive",
+                                                                "normal": "2020/2020"
+                                                            }
+                                                        ],
+                                                        "unitid": "mos_2021_6",
+                                                        "unittitle": {
+                                                            "value": "\u003cspan class=\"ead-emph ead-emph-italic\"\u003eLevel 6\u003c/span\u003e Series I. \u003cspan class=\"ead-persname\"\u003eMegan O'Shea\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e on \u003cspan class=\"ead-corpname\"\u003eNew York University\u003c/span\u003e Here is a \u003cspan class=\"ead-title\"\u003etitle\u003c/span\u003e",
+                                                            "corpname": [
+                                                                {
+                                                                    "value": "New York University"
+                                                                }
+                                                            ],
+                                                            "name": [
+                                                                {
+                                                                    "value": "Rolodex"
+                                                                }
+                                                            ],
+                                                            "persname": [
+                                                                {
+                                                                    "value": "Megan O'Shea"
+                                                                }
+                                                            ],
+                                                            "title": [
+                                                                {
+                                                                    "value": "title"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    "fileplan": [
+                                                        {
+                                                            "id": "aspace_1fa91112393b5806698aa2119e6f9d0a",
+                                                            "head": {
+                                                                "value": "File Plan"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "Level 6 This is the File Plan."
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "index": [
+                                                        {
+                                                            "id": "aspace_4c1c070e35cc0cddc8b73080510ad71a",
+                                                            "head": {
+                                                                "value": "Index head"
+                                                            },
+                                                            "indexentry": [
+                                                                {
+                                                                    "corpname": [
+                                                                        {
+                                                                            "value": "Level 6 Index item"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "p": [
+                                                                {
+                                                                    "value": "Level 6 This is the Index."
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "odd": [
+                                                        {
+                                                            "id": "aspace_cae795bb275b4ac07bfa2a13b22d7e3e",
+                                                            "head": {
+                                                                "value": "General"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "This is the Level 6 General note. \u003cspan class=\"ead-address\"\u003e \u003cspan class=\"ead-addressline\"\u003eElmer Holmes Bobst Library\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003e70 Washington Square South\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003e2nd Floor\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003eNew York, NY 10012\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003especial.collections@nyu.edu\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003eURL: \u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e\u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-abbr\"\u003eALS\u003c/span\u003e \u003cspan class=\"ead-archref\"\u003e \u003ca class=\"ead-extref\" href=\"http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/\" target=\"new\"\u003eThe Sally Belfrage Papers (TAM 189)\u003c/a\u003e\u003c/span\u003e \u003cspan class=\"ead-bibref\"\u003e\u003cspan class=\"ead-emph ead-emph-bold\"\u003eArdouin, Charles Nicholas Celigny\u003c/span\u003e. \u003cspan class=\"ead-title\"\u003eEssais sur l'histoire d'Haiti\u003c/span\u003e. Port-au-Prince, 1865.\u003c/span\u003e \u003cspan class=\"ead-blockquote\"\u003e \u003cspan class=\"ead-p\"\u003eNo doubt the estate has exerted a tremendous influence on the development of my character. One may walk for an hour without glimpsing another soul, which has taught me to love tranquility.\u003c/span\u003e \u003c/span\u003e\u003cbr\u003e \u003cspan class=\"ead-corpname\"\u003eTamiment Library\u003c/span\u003e \u003cspan class=\"ead-date\"\u003eMarch 2021\u003c/span\u003e \u003cspan class=\"ead-list\"\u003e \u003cspan class=\"ead-listhead\"\u003e \u003cspan class=\"ead-head01\"\u003eAbbreviation\u003c/span\u003e \u003cspan class=\"ead-head02\"\u003eExpansion\u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-defitem\"\u003e \u003cspan class=\"ead-label\"\u003eMIT\u003c/span\u003e \u003cspan class=\"ead-item\"\u003eMassachusetts Institute of Technology\u003c/span\u003e \u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e \u003cspan class=\"ead-list\"\u003e \u003cspan class=\"ead-defitem\"\u003e \u003cspan class=\"ead-label\"\u003eMIT\u003c/span\u003e \u003cspan class=\"ead-item\"\u003eMassachusetts Institute of Technology\u003c/span\u003e \u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e",
+                                                                        "abbr": [
+                                                                            "ALS"
+                                                                        ],
+                                                                        "address": [
+                                                                            {
+                                                                                "addressline": [
+                                                                                    {
+                                                                                        "value": "Elmer Holmes Bobst Library"
+                                                                                    },
+                                                                                    {
+                                                                                        "value": "70 Washington Square South"
+                                                                                    },
+                                                                                    {
+                                                                                        "value": "2nd Floor"
+                                                                                    },
+                                                                                    {
+                                                                                        "value": "New York, NY 10012"
+                                                                                    },
+                                                                                    {
+                                                                                        "value": "special.collections@nyu.edu"
+                                                                                    },
+                                                                                    {
+                                                                                        "value": "URL: \u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e",
+                                                                                        "extptr": [
+                                                                                            {
+                                                                                                "href": "http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/",
+                                                                                                "show": "new",
+                                                                                                "title": "http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/",
+                                                                                                "type": "simple"
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ],
+                                                                        "archref": [
+                                                                            {
+                                                                                "value": "\u003ca class=\"ead-extref\" href=\"http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/\" target=\"new\"\u003eThe Sally Belfrage Papers (TAM 189)\u003c/a\u003e"
+                                                                            }
+                                                                        ],
+                                                                        "bibref": [
+                                                                            {
+                                                                                "value": "\u003cspan class=\"ead-emph ead-emph-bold\"\u003eArdouin, Charles Nicholas Celigny\u003c/span\u003e. \u003cspan class=\"ead-title\"\u003eEssais sur l'histoire d'Haiti\u003c/span\u003e. Port-au-Prince, 1865.",
+                                                                                "title": [
+                                                                                    {
+                                                                                        "value": "Essais sur l'histoire d'Haiti",
+                                                                                        "render": "italic"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ],
+                                                                        "corpname": [
+                                                                            {
+                                                                                "value": "Tamiment Library"
+                                                                            }
+                                                                        ],
+                                                                        "date": [
+                                                                            {
+                                                                                "value": "March 2021",
+                                                                                "type": "creation"
+                                                                            }
+                                                                        ],
+                                                                        "genreform": [
+                                                                            "Oral histories (literary works)",
+                                                                            "Oral histories (literary works)"
+                                                                        ],
+                                                                        "list": [
+                                                                            {
+                                                                                "numeration": "arabic",
+                                                                                "type": "deflist",
+                                                                                "defitem": [
+                                                                                    {
+                                                                                        "item": [
+                                                                                            {
+                                                                                                "value": "Massachusetts Institute of Technology"
+                                                                                            }
+                                                                                        ],
+                                                                                        "label": "MIT"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "type": "deflist",
+                                                                                "defitem": [
+                                                                                    {
+                                                                                        "item": [
+                                                                                            {
+                                                                                                "value": "Massachusetts Institute of Technology"
+                                                                                            }
+                                                                                        ],
+                                                                                        "label": "MIT"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ],
+                                                                        "name": [
+                                                                            {
+                                                                                "value": "Rolodex"
+                                                                            },
+                                                                            {
+                                                                                "value": "Rolodex"
+                                                                            }
+                                                                        ],
+                                                                        "num": [
+                                                                            {
+                                                                                "value": "MOS.2021",
+                                                                                "type": "collection"
+                                                                            },
+                                                                            {
+                                                                                "value": "MOS.2021",
+                                                                                "type": "collection"
+                                                                            }
+                                                                        ],
+                                                                        "occupation": [
+                                                                            "Fulbright scholars.",
+                                                                            "Fulbright scholars."
+                                                                        ],
+                                                                        "subject": [
+                                                                            "Irish American women -- History -- 19th century.",
+                                                                            "Irish American women -- History -- 19th century."
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "name": "list",
+                                                                    "value": {
+                                                                        "type": "deflist",
+                                                                        "defitem": [
+                                                                            {
+                                                                                "item": [
+                                                                                    {
+                                                                                        "value": "Massachusetts Institute of Technology"
+                                                                                    }
+                                                                                ],
+                                                                                "label": "MIT"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "\u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e",
+                                                                        "genreform": [
+                                                                            "Oral histories (literary works)"
+                                                                        ],
+                                                                        "name": [
+                                                                            {
+                                                                                "value": "Rolodex"
+                                                                            }
+                                                                        ],
+                                                                        "num": [
+                                                                            {
+                                                                                "value": "MOS.2021",
+                                                                                "type": "collection"
+                                                                            }
+                                                                        ],
+                                                                        "occupation": [
+                                                                            "Fulbright scholars."
+                                                                        ],
+                                                                        "subject": [
+                                                                            "Irish American women -- History -- 19th century."
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "name": "list",
+                                                                    "value": {
+                                                                        "type": "deflist",
+                                                                        "defitem": [
+                                                                            {
+                                                                                "item": [
+                                                                                    {
+                                                                                        "value": "Massachusetts Institute of Technology"
+                                                                                    }
+                                                                                ],
+                                                                                "label": "MIT"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "\u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e",
+                                                                        "genreform": [
+                                                                            "Oral histories (literary works)"
+                                                                        ],
+                                                                        "name": [
+                                                                            {
+                                                                                "value": "Rolodex"
+                                                                            }
+                                                                        ],
+                                                                        "num": [
+                                                                            {
+                                                                                "value": "MOS.2021",
+                                                                                "type": "collection"
+                                                                            }
+                                                                        ],
+                                                                        "occupation": [
+                                                                            "Fulbright scholars."
+                                                                        ],
+                                                                        "subject": [
+                                                                            "Irish American women -- History -- 19th century."
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "otherfindaid": [
+                                                        {
+                                                            "id": "aspace_d86f0ee1ed926e5bda6df6a01fb50430",
+                                                            "head": {
+                                                                "value": "Other Finding Aids"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "Level 6 This is the Other Finding Aids note."
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "originalsloc": [
+                                                        {
+                                                            "id": "aspace_1a9c2d5fe06d96d4356d279fb2a55891",
+                                                            "head": {
+                                                                "value": "Existence and Location of Originals"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "Level 6 This is the Existence and Location of Originals note."
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "phystech": [
+                                                        {
+                                                            "id": "aspace_c9b2395b099958c2c6a4e3a69dc6c9c2",
+                                                            "head": {
+                                                                "value": "Physical Characteristics and Technical Requirements"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "Level 6 This is the Physical Characteristics and Technical Requirements note."
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "prefercite": [
+                                                        {
+                                                            "id": "aspace_e8c53e51987e5304ad271fa53751b542",
+                                                            "head": {
+                                                                "value": "Preferred Citation"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "Level 6 This is the Preferred Citation note."
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "processinfo": [
+                                                        {
+                                                            "id": "aspace_5beb9e56a51c1c7f68772189839b8562",
+                                                            "head": {
+                                                                "value": "Processing Information"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "Level 6 This is the Processing Information note."
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "relatedmaterial": [
+                                                        {
+                                                            "id": "aspace_de6b994fae38995b216e753422b786dd",
+                                                            "head": {
+                                                                "value": "Related Materials"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "Level 6 This is the Related Materials note."
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "scopecontent": [
+                                                        {
+                                                            "id": "aspace_5bada5174e4c359d28a66bcae1732c40",
+                                                            "head": {
+                                                                "value": "Scope and Contents"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "Level 6 This is the Scope and Content note."
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "separatedmaterial": [
+                                                        {
+                                                            "id": "aspace_f83456cccb935c9341a7c4c0bb7af5f6",
+                                                            "head": {
+                                                                "value": "Separated Materials"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "Level 6 This is the Separated Materials note. \u003cspan class=\"ead-archref\"\u003e\u003cspan class=\"ead-physloc\"\u003eBox 152\u003c/span\u003e\u003c/span\u003e",
+                                                                        "archref": [
+                                                                            {
+                                                                                "value": "\u003cspan class=\"ead-physloc\"\u003eBox 152\u003c/span\u003e",
+                                                                                "physloc": [
+                                                                                    {
+                                                                                        "value": "Box 152"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "userestrict": [
+                                                        {
+                                                            "id": "aspace_4178d83cc644ca0b095ad5d7aefded35",
+                                                            "head": {
+                                                                "value": "Conditions Governing Use"
+                                                            },
+                                                            "children": [
+                                                                {
+                                                                    "name": "p",
+                                                                    "value": {
+                                                                        "value": "Level 6 This is the Conditions Governing Use note."
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "controlaccess": [
+                                                {
+                                                    "corpname": [
+                                                        {
+                                                            "value": "Tamiment Library"
+                                                        }
+                                                    ],
+                                                    "famname": [
+                                                        {
+                                                            "value": "Belfrage family"
+                                                        }
+                                                    ],
+                                                    "function": [
+                                                        {
+                                                            "value": "War Powers Conference"
+                                                        }
+                                                    ],
+                                                    "genreform": [
+                                                        {
+                                                            "value": "Oral histories (literary works)"
+                                                        }
+                                                    ],
+                                                    "geogname": [
+                                                        {
+                                                            "value": "Boston (Mass.) -- Intellectual life -- 20th century."
+                                                        }
+                                                    ],
+                                                    "occupation": [
+                                                        {
+                                                            "value": "Fulbright scholars."
+                                                        }
+                                                    ],
+                                                    "subject": [
+                                                        {
+                                                            "value": "Irish American women -- History -- 19th century."
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "custodhist": [
+                                                {
+                                                    "id": "aspace_a0164cc049fccf4f6e35d807eba828ae",
+                                                    "head": {
+                                                        "value": "Custodial History"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "Level 5 This is the Custodial History note."
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "did": {
+                                                "physdesc": [
+                                                    {
+                                                        "value": "\u003cspan class=\"ead-extent\"\u003e5 Linear Feet\u003c/span\u003e\u003cspan class=\"ead-extent\"\u003ein 24 record cartons, 1 manuscript box, and 1 flat file folder\u003c/span\u003e\u003cspan class=\"ead-physfacet\"\u003eThis is still a test\u003c/span\u003e\u003cspan class=\"ead-dimensions\"\u003e7\" x 45'\u003c/span\u003e",
+                                                        "altrender": "whole",
+                                                        "extent": [
+                                                            {
+                                                                "value": "5 Linear Feet",
+                                                                "altrender": "materialtype spaceoccupied"
+                                                            },
+                                                            {
+                                                                "value": "in 24 record cartons, 1 manuscript box, and 1 flat file folder",
+                                                                "altrender": "carrier"
+                                                            }
+                                                        ],
+                                                        "dimensions": {
+                                                            "value": "7\" x 45'"
+                                                        },
+                                                        "physfacet": {
+                                                            "value": "This is still a test"
+                                                        }
+                                                    },
+                                                    {
+                                                        "value": "Level 5 This is the Physical Description note.",
+                                                        "id": "aspace_28df7326e65493e2fc1ec9654617ef0e",
+                                                        "label": "Physical Description"
+                                                    }
+                                                ],
+                                                "abstract": [
+                                                    {
+                                                        "value": "Level 5 \u003cspan class=\"ead-emph ead-emph-bold\"\u003eThis is\u003c/span\u003e the \u003cspan class=\"ead-title\"\u003eAbstract\u003c/span\u003e. It has a \u003cspan class=\"ead-title\"\u003e\u003cspan class=\"ead-emph ead-emph-bold\"\u003ebold \u003c/span\u003etitle\u003c/span\u003e in it.",
+                                                        "id": "aspace_249a3fdd9a6970f7261ef73ed5a82c33",
+                                                        "title": [
+                                                            {
+                                                                "value": "Abstract"
+                                                            },
+                                                            {
+                                                                "value": "\u003cspan class=\"ead-emph ead-emph-bold\"\u003ebold \u003c/span\u003etitle",
+                                                                "render": "bold",
+                                                                "source": "DACS",
+                                                                "type": "book"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "container": [
+                                                    {
+                                                        "value": "1",
+                                                        "altrender": "Record carton",
+                                                        "id": "aspace_9fc2c4c89b5765e325dd8ece336e4fc5",
+                                                        "label": "mixed materials",
+                                                        "type": "box"
+                                                    },
+                                                    {
+                                                        "value": "1",
+                                                        "id": "aspace_663e58ec96e9f1a1ff597923c2c9c766",
+                                                        "parent": "aspace_9fc2c4c89b5765e325dd8ece336e4fc5",
+                                                        "type": "folder"
+                                                    }
+                                                ],
+                                                "dao": [
+                                                    {
+                                                        "actuate": "onRequest",
+                                                        "href": "https://hdl.handle.net/2333.1/xgxd28gq",
+                                                        "role": "image-service",
+                                                        "show": "new",
+                                                        "title": "This is a digital object",
+                                                        "type": "simple",
+                                                        "daodesc": {
+                                                            "p": [
+                                                                {
+                                                                    "value": "This is a digital object"
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ],
+                                                "daogrp": [
+                                                    {
+                                                        "title": "Archived website of Julie Kathryn",
+                                                        "type": "extended",
+                                                        "daodesc": {
+                                                            "p": [
+                                                                {
+                                                                    "value": "Archived website of Julie Kathryn"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "daoloc": [
+                                                            {
+                                                                "href": "https://wayback.archive-it.org/9900/*/http://www.iamsnowangel.com",
+                                                                "role": "external-link",
+                                                                "title": "Archived website of Julie Kathryn",
+                                                                "type": "locator"
+                                                            },
+                                                            {
+                                                                "href": "https://wayback.archive-it.org/4049/*/http://www.iamsnowangel.com",
+                                                                "role": "external-link",
+                                                                "title": "Archived website of Julie Kathryn",
+                                                                "type": "locator"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "langmaterial": [
+                                                    {
+                                                        "value": "Level 5 \u003cspan class=\"ead-emph ead-emph-italic\"\u003eMaterials\u003c/span\u003e are in \u003cspan class=\"ead-language\"\u003eEnglish\u003c/span\u003e.",
+                                                        "id": "aspace_9b0efe097064eb3e852f801492847a37",
+                                                        "language": [
+                                                            "English"
+                                                        ]
+                                                    }
+                                                ],
+                                                "materialspec": [
+                                                    {
+                                                        "id": "aspace_ed591019ee2e31b0ed6321587349ae04",
+                                                        "children": [
+                                                            {
+                                                                "name": "div",
+                                                                "value": {
+                                                                    "value": "Level 5 This is the Materials Specific Details note."
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "origination": [
+                                                    {
+                                                        "label": "Creator",
+                                                        "corpname": [
+                                                            {
+                                                                "value": "World Trade Center (New York, N.Y.)"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "label": "Creator",
+                                                        "famname": [
+                                                            {
+                                                                "value": "Draper family"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "label": "Creator",
+                                                        "persname": [
+                                                            {
+                                                                "value": "Yonge, Charlotte Mary, 1823-1901"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "physloc": [
+                                                    {
+                                                        "value": "Level 5 This is the Physical Location note.",
+                                                        "id": "aspace_a56d52abb5da53cd39c1a7594080266b"
+                                                    },
+                                                    {
+                                                        "value": "Box 152",
+                                                        "id": "aspace_f08355ba37e1a342766ef0031cf92f7c"
+                                                    }
+                                                ],
+                                                "unitdate": [
+                                                    {
+                                                        "value": "2015-2019",
+                                                        "type": "inclusive",
+                                                        "normal": "2015/2019"
+                                                    }
+                                                ],
+                                                "unitid": "mos_2021_5",
+                                                "unittitle": {
+                                                    "value": "\u003cspan class=\"ead-emph ead-emph-italic\"\u003eLevel 5\u003c/span\u003e Series I. \u003cspan class=\"ead-persname\"\u003eMegan O'Shea\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cbr\u003eon \u003cspan class=\"ead-corpname\"\u003eNew York University\u003c/span\u003e Here is a \u003cspan class=\"ead-title\"\u003etitle\u003c/span\u003e",
+                                                    "corpname": [
+                                                        {
+                                                            "value": "New York University"
+                                                        }
+                                                    ],
+                                                    "name": [
+                                                        {
+                                                            "value": "Rolodex"
+                                                        }
+                                                    ],
+                                                    "persname": [
+                                                        {
+                                                            "value": "Megan O'Shea"
+                                                        }
+                                                    ],
+                                                    "title": [
+                                                        {
+                                                            "value": "title"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "fileplan": [
+                                                {
+                                                    "id": "aspace_157a5a813a2ad425952ce917fc18e4fe",
+                                                    "head": {
+                                                        "value": "File Plan"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "Level 5 This is the File Plan."
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "index": [
+                                                {
+                                                    "id": "aspace_e6ff06ec5d33f393d3622b04ba54e7e1",
+                                                    "head": {
+                                                        "value": "Index head"
+                                                    },
+                                                    "indexentry": [
+                                                        {
+                                                            "corpname": [
+                                                                {
+                                                                    "value": "Level 5 Index Item"
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "p": [
+                                                        {
+                                                            "value": "Level 5 This is the Index."
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "odd": [
+                                                {
+                                                    "id": "aspace_b4c220c97316431abaf744f6444e431d",
+                                                    "head": {
+                                                        "value": "General"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "This is the Level 5 General note. \u003cspan class=\"ead-address\"\u003e \u003cspan class=\"ead-addressline\"\u003eElmer Holmes Bobst Library\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003e70 Washington Square South\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003e2nd Floor\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003eNew York, NY 10012\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003especial.collections@nyu.edu\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003eURL: \u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e\u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-abbr\"\u003eALS\u003c/span\u003e \u003cspan class=\"ead-archref\"\u003e \u003ca class=\"ead-extref\" href=\"http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/\" target=\"new\"\u003eThe Sally Belfrage Papers (TAM 189)\u003c/a\u003e\u003c/span\u003e \u003cspan class=\"ead-bibref\"\u003e\u003cspan class=\"ead-emph ead-emph-bold\"\u003eArdouin, Charles Nicholas Celigny\u003c/span\u003e. \u003cspan class=\"ead-title\"\u003eEssais sur l'histoire d'Haiti\u003c/span\u003e. Port-au-Prince, 1865.\u003c/span\u003e \u003cspan class=\"ead-blockquote\"\u003e \u003cspan class=\"ead-p\"\u003eNo doubt the estate has exerted a tremendous influence on the development of my character. One may walk for an hour without glimpsing another soul, which has taught me to love tranquility.\u003c/span\u003e \u003c/span\u003e\u003cbr\u003e \u003cspan class=\"ead-corpname\"\u003eTamiment Library\u003c/span\u003e \u003cspan class=\"ead-date\"\u003eMarch 2021\u003c/span\u003e \u003cspan class=\"ead-list\"\u003e \u003cspan class=\"ead-listhead\"\u003e \u003cspan class=\"ead-head01\"\u003eAbbreviation\u003c/span\u003e \u003cspan class=\"ead-head02\"\u003eExpansion\u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-defitem\"\u003e \u003cspan class=\"ead-label\"\u003eMIT\u003c/span\u003e \u003cspan class=\"ead-item\"\u003eMassachusetts Institute of Technology\u003c/span\u003e \u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e \u003cspan class=\"ead-list\"\u003e \u003cspan class=\"ead-defitem\"\u003e \u003cspan class=\"ead-label\"\u003eMIT\u003c/span\u003e \u003cspan class=\"ead-item\"\u003eMassachusetts Institute of Technology\u003c/span\u003e \u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e",
+                                                                "abbr": [
+                                                                    "ALS"
+                                                                ],
+                                                                "address": [
+                                                                    {
+                                                                        "addressline": [
+                                                                            {
+                                                                                "value": "Elmer Holmes Bobst Library"
+                                                                            },
+                                                                            {
+                                                                                "value": "70 Washington Square South"
+                                                                            },
+                                                                            {
+                                                                                "value": "2nd Floor"
+                                                                            },
+                                                                            {
+                                                                                "value": "New York, NY 10012"
+                                                                            },
+                                                                            {
+                                                                                "value": "special.collections@nyu.edu"
+                                                                            },
+                                                                            {
+                                                                                "value": "URL: \u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e",
+                                                                                "extptr": [
+                                                                                    {
+                                                                                        "href": "http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/",
+                                                                                        "show": "new",
+                                                                                        "title": "http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/",
+                                                                                        "type": "simple"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ],
+                                                                "archref": [
+                                                                    {
+                                                                        "value": "\u003ca class=\"ead-extref\" href=\"http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/\" target=\"new\"\u003eThe Sally Belfrage Papers (TAM 189)\u003c/a\u003e"
+                                                                    }
+                                                                ],
+                                                                "bibref": [
+                                                                    {
+                                                                        "value": "\u003cspan class=\"ead-emph ead-emph-bold\"\u003eArdouin, Charles Nicholas Celigny\u003c/span\u003e. \u003cspan class=\"ead-title\"\u003eEssais sur l'histoire d'Haiti\u003c/span\u003e. Port-au-Prince, 1865.",
+                                                                        "title": [
+                                                                            {
+                                                                                "value": "Essais sur l'histoire d'Haiti",
+                                                                                "render": "italic"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ],
+                                                                "corpname": [
+                                                                    {
+                                                                        "value": "Tamiment Library"
+                                                                    }
+                                                                ],
+                                                                "date": [
+                                                                    {
+                                                                        "value": "March 2021",
+                                                                        "type": "creation"
+                                                                    }
+                                                                ],
+                                                                "genreform": [
+                                                                    "Oral histories (literary works)",
+                                                                    "Oral histories (literary works)"
+                                                                ],
+                                                                "list": [
+                                                                    {
+                                                                        "numeration": "arabic",
+                                                                        "type": "deflist",
+                                                                        "defitem": [
+                                                                            {
+                                                                                "item": [
+                                                                                    {
+                                                                                        "value": "Massachusetts Institute of Technology"
+                                                                                    }
+                                                                                ],
+                                                                                "label": "MIT"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "deflist",
+                                                                        "defitem": [
+                                                                            {
+                                                                                "item": [
+                                                                                    {
+                                                                                        "value": "Massachusetts Institute of Technology"
+                                                                                    }
+                                                                                ],
+                                                                                "label": "MIT"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ],
+                                                                "name": [
+                                                                    {
+                                                                        "value": "Rolodex"
+                                                                    },
+                                                                    {
+                                                                        "value": "Rolodex"
+                                                                    }
+                                                                ],
+                                                                "num": [
+                                                                    {
+                                                                        "value": "MOS.2021",
+                                                                        "type": "collection"
+                                                                    },
+                                                                    {
+                                                                        "value": "MOS.2021",
+                                                                        "type": "collection"
+                                                                    }
+                                                                ],
+                                                                "occupation": [
+                                                                    "Fulbright scholars.",
+                                                                    "Fulbright scholars."
+                                                                ],
+                                                                "subject": [
+                                                                    "Irish American women -- History -- 19th century.",
+                                                                    "Irish American women -- History -- 19th century."
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "name": "list",
+                                                            "value": {
+                                                                "type": "deflist",
+                                                                "defitem": [
+                                                                    {
+                                                                        "item": [
+                                                                            {
+                                                                                "value": "Massachusetts Institute of Technology"
+                                                                            }
+                                                                        ],
+                                                                        "label": "MIT"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "\u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e",
+                                                                "genreform": [
+                                                                    "Oral histories (literary works)"
+                                                                ],
+                                                                "name": [
+                                                                    {
+                                                                        "value": "Rolodex"
+                                                                    }
+                                                                ],
+                                                                "num": [
+                                                                    {
+                                                                        "value": "MOS.2021",
+                                                                        "type": "collection"
+                                                                    }
+                                                                ],
+                                                                "occupation": [
+                                                                    "Fulbright scholars."
+                                                                ],
+                                                                "subject": [
+                                                                    "Irish American women -- History -- 19th century."
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "name": "list",
+                                                            "value": {
+                                                                "type": "deflist",
+                                                                "defitem": [
+                                                                    {
+                                                                        "item": [
+                                                                            {
+                                                                                "value": "Massachusetts Institute of Technology"
+                                                                            }
+                                                                        ],
+                                                                        "label": "MIT"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "\u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e",
+                                                                "genreform": [
+                                                                    "Oral histories (literary works)"
+                                                                ],
+                                                                "name": [
+                                                                    {
+                                                                        "value": "Rolodex"
+                                                                    }
+                                                                ],
+                                                                "num": [
+                                                                    {
+                                                                        "value": "MOS.2021",
+                                                                        "type": "collection"
+                                                                    }
+                                                                ],
+                                                                "occupation": [
+                                                                    "Fulbright scholars."
+                                                                ],
+                                                                "subject": [
+                                                                    "Irish American women -- History -- 19th century."
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "otherfindaid": [
+                                                {
+                                                    "id": "aspace_095dd2c0215f9cb9f18f3cd47ae78ad1",
+                                                    "head": {
+                                                        "value": "Other Finding Aids"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "Level 5 This is the Other Finding Aids note."
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "originalsloc": [
+                                                {
+                                                    "id": "aspace_b1baecf704266074bb5ed0668bd48664",
+                                                    "head": {
+                                                        "value": "Existence and Location of Originals"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "Level 5 This is the Existence and Location of Originals note."
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "phystech": [
+                                                {
+                                                    "id": "aspace_9a810d283ec1171c095471c97584356a",
+                                                    "head": {
+                                                        "value": "Physical Characteristics and Technical Requirements"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "Level 5 This is the Physical Characteristics and Technical Requirements note."
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "prefercite": [
+                                                {
+                                                    "id": "aspace_da13d87ab539adcb04d8cc4788a403a2",
+                                                    "head": {
+                                                        "value": "Preferred Citation"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "Level 5 This is the Preferred Citation note."
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "processinfo": [
+                                                {
+                                                    "id": "aspace_489f3c28a4edd7f9c35caf86eda1c3e4",
+                                                    "head": {
+                                                        "value": "Processing Information"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "Level 5 This is the Processing Information note."
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "relatedmaterial": [
+                                                {
+                                                    "id": "aspace_3effcf63108f278a01b02287bb608ea1",
+                                                    "head": {
+                                                        "value": "Related Materials"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "Level 5 This is the Related Materials note."
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "scopecontent": [
+                                                {
+                                                    "id": "aspace_c4d67d6cbeab9c4e9fc0e6848d58de22",
+                                                    "head": {
+                                                        "value": "Scope and Contents"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "Level 5 This is the Scope and Content note."
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "separatedmaterial": [
+                                                {
+                                                    "id": "aspace_32388aa060e68f3a9b9c3c603bb61013",
+                                                    "head": {
+                                                        "value": "Separated Materials"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "Level 5 This is the Separated Materials note. \u003cspan class=\"ead-archref\"\u003e\u003cspan class=\"ead-physloc\"\u003eBox 152\u003c/span\u003e\u003c/span\u003e",
+                                                                "archref": [
+                                                                    {
+                                                                        "value": "\u003cspan class=\"ead-physloc\"\u003eBox 152\u003c/span\u003e",
+                                                                        "physloc": [
+                                                                            {
+                                                                                "value": "Box 152"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "userestrict": [
+                                                {
+                                                    "id": "aspace_3b4710103c1ea86472fd2ba940d2bc34",
+                                                    "head": {
+                                                        "value": "Conditions Governing Use"
+                                                    },
+                                                    "children": [
+                                                        {
+                                                            "name": "p",
+                                                            "value": {
+                                                                "value": "Level 5 This is the Conditions Governing Use note."
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "controlaccess": [
+                                        {
+                                            "corpname": [
+                                                {
+                                                    "value": "Tamiment Library"
+                                                }
+                                            ],
+                                            "famname": [
+                                                {
+                                                    "value": "Belfrage family"
+                                                }
+                                            ],
+                                            "function": [
+                                                {
+                                                    "value": "War Powers Conference"
+                                                }
+                                            ],
+                                            "genreform": [
+                                                {
+                                                    "value": "Oral histories (literary works)"
+                                                }
+                                            ],
+                                            "geogname": [
+                                                {
+                                                    "value": "Boston (Mass.) -- Intellectual life -- 20th century."
+                                                }
+                                            ],
+                                            "occupation": [
+                                                {
+                                                    "value": "Fulbright scholars."
+                                                }
+                                            ],
+                                            "subject": [
+                                                {
+                                                    "value": "Irish American women -- History -- 19th century."
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "custodhist": [
+                                        {
+                                            "id": "aspace_cd438d2283bbc46dba9b6bf0e3bfd48f",
+                                            "head": {
+                                                "value": "Custodial History"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "Level 4 This is the Custodial History note."
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "did": {
+                                        "physdesc": [
+                                            {
+                                                "value": "\u003cspan class=\"ead-extent\"\u003e2 Linear Feet\u003c/span\u003e\u003cspan class=\"ead-extent\"\u003ein 24 record cartons, 1 manuscript box, and 1 flat file folder\u003c/span\u003e\u003cspan class=\"ead-physfacet\"\u003eThis is a test\u003c/span\u003e\u003cspan class=\"ead-dimensions\"\u003e1' x 27\"\u003c/span\u003e",
+                                                "altrender": "whole",
+                                                "extent": [
+                                                    {
+                                                        "value": "2 Linear Feet",
+                                                        "altrender": "materialtype spaceoccupied"
+                                                    },
+                                                    {
+                                                        "value": "in 24 record cartons, 1 manuscript box, and 1 flat file folder",
+                                                        "altrender": "carrier"
+                                                    }
+                                                ],
+                                                "dimensions": {
+                                                    "value": "1' x 27\""
+                                                },
+                                                "physfacet": {
+                                                    "value": "This is a test"
+                                                }
+                                            },
+                                            {
+                                                "value": "Level 4 This is the Physical Description note.",
+                                                "id": "aspace_478bdf2b485ef16a9da865d1deef629c",
+                                                "label": "Physical Description"
+                                            }
+                                        ],
+                                        "abstract": [
+                                            {
+                                                "value": "Level 4 \u003cspan class=\"ead-emph ead-emph-italic\"\u003eThis\u003c/span\u003e is the \u003cspan class=\"ead-title\"\u003eAbstract\u003c/span\u003e.It has a \u003cspan class=\"ead-title\"\u003e\u003cspan class=\"ead-emph ead-emph-bold\"\u003ebold \u003c/span\u003etitle\u003c/span\u003e in it.",
+                                                "id": "aspace_3d9720d0bacf6d3d15ac94b5ce37e689",
+                                                "title": [
+                                                    {
+                                                        "value": "Abstract"
+                                                    },
+                                                    {
+                                                        "value": "\u003cspan class=\"ead-emph ead-emph-bold\"\u003ebold \u003c/span\u003etitle",
+                                                        "render": "bold",
+                                                        "source": "DACS",
+                                                        "type": "book"
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "container": [
+                                            {
+                                                "value": "1",
+                                                "altrender": "Record carton",
+                                                "id": "aspace_277369e5dfa81775c973da42ed84b647",
+                                                "label": "mixed materials",
+                                                "type": "box"
+                                            },
+                                            {
+                                                "value": "1",
+                                                "id": "aspace_0e914532f0cc92734c6e1100bd0d6af1",
+                                                "parent": "aspace_277369e5dfa81775c973da42ed84b647",
+                                                "type": "folder"
+                                            }
+                                        ],
+                                        "dao": [
+                                            {
+                                                "actuate": "onRequest",
+                                                "href": "https://hdl.handle.net/2333.1/m63xss7g",
+                                                "role": "image-service",
+                                                "show": "new",
+                                                "title": "This is a digital object",
+                                                "type": "simple",
+                                                "daodesc": {
+                                                    "p": [
+                                                        {
+                                                            "value": "This is a digital object"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ],
+                                        "daogrp": [
+                                            {
+                                                "title": "Archived website of Julie Kathryn",
+                                                "type": "extended",
+                                                "daodesc": {
+                                                    "p": [
+                                                        {
+                                                            "value": "Archived website of Julie Kathryn"
+                                                        }
+                                                    ]
+                                                },
+                                                "daoloc": [
+                                                    {
+                                                        "href": "https://wayback.archive-it.org/9900/*/http://www.iamsnowangel.com",
+                                                        "role": "external-link",
+                                                        "title": "Archived website of Julie Kathryn",
+                                                        "type": "locator"
+                                                    },
+                                                    {
+                                                        "href": "https://wayback.archive-it.org/4049/*/http://www.iamsnowangel.com",
+                                                        "role": "external-link",
+                                                        "title": "Archived website of Julie Kathryn",
+                                                        "type": "locator"
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "langmaterial": [
+                                            {
+                                                "value": "Level 4 \u003cspan class=\"ead-emph ead-emph-bold\"\u003eMaterials\u003c/span\u003e in \u003cspan class=\"ead-language\"\u003eEnglish\u003c/span\u003e.",
+                                                "id": "aspace_e89995070ff1a0de51f06a08c03193c7",
+                                                "language": [
+                                                    "English"
+                                                ]
+                                            }
+                                        ],
+                                        "materialspec": [
+                                            {
+                                                "id": "aspace_bb766f2f7183c55973b1b8097f44002f",
+                                                "children": [
+                                                    {
+                                                        "name": "div",
+                                                        "value": {
+                                                            "value": "Level 4 This is the Materials Specific Details note."
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "origination": [
+                                            {
+                                                "label": "Creator",
+                                                "corpname": [
+                                                    {
+                                                        "value": "Yivo Institute for Jewish Research"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "label": "Creator",
+                                                "famname": [
+                                                    {
+                                                        "value": "Pinsof family"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "label": "Creator",
+                                                "persname": [
+                                                    {
+                                                        "value": "Zwillinger, Rhonda"
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "physloc": [
+                                            {
+                                                "value": "Level 4 This is the Physical Location note.",
+                                                "id": "aspace_b6521902953af6f8eb7c33b079f834df"
+                                            },
+                                            {
+                                                "value": "Box 152",
+                                                "id": "aspace_aec0166edc173f05326763b6b488cf26"
+                                            }
+                                        ],
+                                        "unitdate": [
+                                            {
+                                                "value": "2017-2019",
+                                                "type": "inclusive",
+                                                "normal": "2017/2019"
+                                            }
+                                        ],
+                                        "unitid": "mos_2021_4",
+                                        "unittitle": {
+                                            "value": "\u003cspan class=\"ead-emph ead-emph-italic\"\u003eLevel 4\u003c/span\u003e Series I. \u003cspan class=\"ead-persname\"\u003eMegan O'Shea\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e on \u003cspan class=\"ead-corpname\"\u003eNew York University\u003c/span\u003e Here is a \u003cspan class=\"ead-title\"\u003etitle\u003c/span\u003e",
+                                            "corpname": [
+                                                {
+                                                    "value": "New York University"
+                                                }
+                                            ],
+                                            "name": [
+                                                {
+                                                    "value": "Rolodex"
+                                                }
+                                            ],
+                                            "persname": [
+                                                {
+                                                    "value": "Megan O'Shea"
+                                                }
+                                            ],
+                                            "title": [
+                                                {
+                                                    "value": "title"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "fileplan": [
+                                        {
+                                            "id": "aspace_263cb0600aa30a376f230fdd767ef140",
+                                            "head": {
+                                                "value": "File Plan"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "Level 4 This is the File Plan."
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "index": [
+                                        {
+                                            "id": "aspace_472965efae0a7e6f937feb7775d565c6",
+                                            "head": {
+                                                "value": "Index head"
+                                            },
+                                            "indexentry": [
+                                                {
+                                                    "corpname": [
+                                                        {
+                                                            "value": "Level 4 Index item"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "p": [
+                                                {
+                                                    "value": "Level 4 This is the Index."
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "odd": [
+                                        {
+                                            "id": "aspace_5663cc33576c4f60a114a09d5372c8fe",
+                                            "head": {
+                                                "value": "General"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "This is the Level 4 General note. \u003cspan class=\"ead-address\"\u003e \u003cspan class=\"ead-addressline\"\u003eElmer Holmes Bobst Library\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003e70 Washington Square South\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003e2nd Floor\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003eNew York, NY 10012\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003especial.collections@nyu.edu\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003eURL: \u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e\u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-abbr\"\u003eALS\u003c/span\u003e \u003cspan class=\"ead-archref\"\u003e \u003ca class=\"ead-extref\" href=\"http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/\" target=\"new\"\u003eThe Sally Belfrage Papers (TAM 189)\u003c/a\u003e\u003c/span\u003e \u003cspan class=\"ead-bibref\"\u003e\u003cspan class=\"ead-emph ead-emph-bold\"\u003eArdouin, Charles Nicholas Celigny\u003c/span\u003e. \u003cspan class=\"ead-title\"\u003eEssais sur l'histoire d'Haiti\u003c/span\u003e. Port-au-Prince, 1865.\u003c/span\u003e \u003cspan class=\"ead-blockquote\"\u003e \u003cspan class=\"ead-p\"\u003eNo doubt the estate has exerted a tremendous influence on the development of my character. One may walk for an hour without glimpsing another soul, which has taught me to love tranquility.\u003c/span\u003e \u003c/span\u003e\u003cbr\u003e \u003cspan class=\"ead-corpname\"\u003eTamiment Library\u003c/span\u003e \u003cspan class=\"ead-date\"\u003eMarch 2021\u003c/span\u003e \u003cspan class=\"ead-list\"\u003e \u003cspan class=\"ead-listhead\"\u003e \u003cspan class=\"ead-head01\"\u003eAbbreviation\u003c/span\u003e \u003cspan class=\"ead-head02\"\u003eExpansion\u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-defitem\"\u003e \u003cspan class=\"ead-label\"\u003eMIT\u003c/span\u003e \u003cspan class=\"ead-item\"\u003eMassachusetts Institute of Technology\u003c/span\u003e \u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e \u003cspan class=\"ead-list\"\u003e \u003cspan class=\"ead-defitem\"\u003e \u003cspan class=\"ead-label\"\u003eMIT\u003c/span\u003e \u003cspan class=\"ead-item\"\u003eMassachusetts Institute of Technology\u003c/span\u003e \u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e",
+                                                        "abbr": [
+                                                            "ALS"
+                                                        ],
+                                                        "address": [
+                                                            {
+                                                                "addressline": [
+                                                                    {
+                                                                        "value": "Elmer Holmes Bobst Library"
+                                                                    },
+                                                                    {
+                                                                        "value": "70 Washington Square South"
+                                                                    },
+                                                                    {
+                                                                        "value": "2nd Floor"
+                                                                    },
+                                                                    {
+                                                                        "value": "New York, NY 10012"
+                                                                    },
+                                                                    {
+                                                                        "value": "special.collections@nyu.edu"
+                                                                    },
+                                                                    {
+                                                                        "value": "URL: \u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e",
+                                                                        "extptr": [
+                                                                            {
+                                                                                "href": "http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/",
+                                                                                "show": "new",
+                                                                                "title": "http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/",
+                                                                                "type": "simple"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ],
+                                                        "archref": [
+                                                            {
+                                                                "value": "\u003ca class=\"ead-extref\" href=\"http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/\" target=\"new\"\u003eThe Sally Belfrage Papers (TAM 189)\u003c/a\u003e"
+                                                            }
+                                                        ],
+                                                        "bibref": [
+                                                            {
+                                                                "value": "\u003cspan class=\"ead-emph ead-emph-bold\"\u003eArdouin, Charles Nicholas Celigny\u003c/span\u003e. \u003cspan class=\"ead-title\"\u003eEssais sur l'histoire d'Haiti\u003c/span\u003e. Port-au-Prince, 1865.",
+                                                                "title": [
+                                                                    {
+                                                                        "value": "Essais sur l'histoire d'Haiti",
+                                                                        "render": "italic"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ],
+                                                        "corpname": [
+                                                            {
+                                                                "value": "Tamiment Library"
+                                                            }
+                                                        ],
+                                                        "date": [
+                                                            {
+                                                                "value": "March 2021",
+                                                                "type": "creation"
+                                                            }
+                                                        ],
+                                                        "genreform": [
+                                                            "Oral histories (literary works)",
+                                                            "Oral histories (literary works)"
+                                                        ],
+                                                        "list": [
+                                                            {
+                                                                "numeration": "arabic",
+                                                                "type": "deflist",
+                                                                "defitem": [
+                                                                    {
+                                                                        "item": [
+                                                                            {
+                                                                                "value": "Massachusetts Institute of Technology"
+                                                                            }
+                                                                        ],
+                                                                        "label": "MIT"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "deflist",
+                                                                "defitem": [
+                                                                    {
+                                                                        "item": [
+                                                                            {
+                                                                                "value": "Massachusetts Institute of Technology"
+                                                                            }
+                                                                        ],
+                                                                        "label": "MIT"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ],
+                                                        "name": [
+                                                            {
+                                                                "value": "Rolodex"
+                                                            },
+                                                            {
+                                                                "value": "Rolodex"
+                                                            }
+                                                        ],
+                                                        "num": [
+                                                            {
+                                                                "value": "MOS.2021",
+                                                                "type": "collection"
+                                                            },
+                                                            {
+                                                                "value": "MOS.2021",
+                                                                "type": "collection"
+                                                            }
+                                                        ],
+                                                        "occupation": [
+                                                            "Fulbright scholars.",
+                                                            "Fulbright scholars."
+                                                        ],
+                                                        "subject": [
+                                                            "Irish American women -- History -- 19th century.",
+                                                            "Irish American women -- History -- 19th century."
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "name": "list",
+                                                    "value": {
+                                                        "type": "deflist",
+                                                        "defitem": [
+                                                            {
+                                                                "item": [
+                                                                    {
+                                                                        "value": "Massachusetts Institute of Technology"
+                                                                    }
+                                                                ],
+                                                                "label": "MIT"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "\u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e",
+                                                        "genreform": [
+                                                            "Oral histories (literary works)"
+                                                        ],
+                                                        "name": [
+                                                            {
+                                                                "value": "Rolodex"
+                                                            }
+                                                        ],
+                                                        "num": [
+                                                            {
+                                                                "value": "MOS.2021",
+                                                                "type": "collection"
+                                                            }
+                                                        ],
+                                                        "occupation": [
+                                                            "Fulbright scholars."
+                                                        ],
+                                                        "subject": [
+                                                            "Irish American women -- History -- 19th century."
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "name": "list",
+                                                    "value": {
+                                                        "type": "deflist",
+                                                        "defitem": [
+                                                            {
+                                                                "item": [
+                                                                    {
+                                                                        "value": "Massachusetts Institute of Technology"
+                                                                    }
+                                                                ],
+                                                                "label": "MIT"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "\u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e",
+                                                        "genreform": [
+                                                            "Oral histories (literary works)"
+                                                        ],
+                                                        "name": [
+                                                            {
+                                                                "value": "Rolodex"
+                                                            }
+                                                        ],
+                                                        "num": [
+                                                            {
+                                                                "value": "MOS.2021",
+                                                                "type": "collection"
+                                                            }
+                                                        ],
+                                                        "occupation": [
+                                                            "Fulbright scholars."
+                                                        ],
+                                                        "subject": [
+                                                            "Irish American women -- History -- 19th century."
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "otherfindaid": [
+                                        {
+                                            "id": "aspace_30e9a550325592d2c580ae2fa14bad16",
+                                            "head": {
+                                                "value": "Other Finding Aids"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "Level 4 This is the Other Finding Aids note."
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "originalsloc": [
+                                        {
+                                            "id": "aspace_9c9019e5330b43c5aff473a3cb2e6c04",
+                                            "head": {
+                                                "value": "Existence and Location of Originals"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "Level 4 This is the Existence and Location of Originals note."
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "phystech": [
+                                        {
+                                            "id": "aspace_cb37b719b582123d998dff13855d5343",
+                                            "head": {
+                                                "value": "Physical Characteristics and Technical Requirements"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "Level 4 This is the Physical Characteristics and Technical Requirements note."
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "prefercite": [
+                                        {
+                                            "id": "aspace_caee1a0b9dcfc598055681a91291f2bb",
+                                            "head": {
+                                                "value": "Preferred Citation"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "Level 4 This is the Preferred Citation note."
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "processinfo": [
+                                        {
+                                            "id": "aspace_1abcc14a1a9bf406c9c3856ddd01d794",
+                                            "head": {
+                                                "value": "Processing Information"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "Level 4 This is the Processing Information note."
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "relatedmaterial": [
+                                        {
+                                            "id": "aspace_37d44617b518963f97002b3a32ec14be",
+                                            "head": {
+                                                "value": "Related Materials"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "Level 4 This is the Related Materials note."
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "scopecontent": [
+                                        {
+                                            "id": "aspace_7d9603f358e3cb5551b55cee34a0f85a",
+                                            "head": {
+                                                "value": "Scope and Contents"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "Level 4 This is the Scope and Content note."
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "separatedmaterial": [
+                                        {
+                                            "id": "aspace_ce804033f1c4a4f7a47d1ae23b8a82b0",
+                                            "head": {
+                                                "value": "Separated Materials"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "Level 4 This is the Separated Materials note. \u003cspan class=\"ead-archref\"\u003e\u003cspan class=\"ead-physloc\"\u003eBox 152\u003c/span\u003e\u003c/span\u003e",
+                                                        "archref": [
+                                                            {
+                                                                "value": "\u003cspan class=\"ead-physloc\"\u003eBox 152\u003c/span\u003e",
+                                                                "physloc": [
+                                                                    {
+                                                                        "value": "Box 152"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "userestrict": [
+                                        {
+                                            "id": "aspace_2f463c22696e1024a8eda0a1f251b16f",
+                                            "head": {
+                                                "value": "Conditions Governing Use"
+                                            },
+                                            "children": [
+                                                {
+                                                    "name": "p",
+                                                    "value": {
+                                                        "value": "Level 4 This is the Conditions Governing Use note."
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "controlaccess": [
+                                {
+                                    "corpname": [
+                                        {
+                                            "value": "Tamiment Library"
+                                        }
+                                    ],
+                                    "famname": [
+                                        {
+                                            "value": "Belfrage family"
+                                        }
+                                    ],
+                                    "function": [
+                                        {
+                                            "value": "War Powers Conference"
+                                        }
+                                    ],
+                                    "genreform": [
+                                        {
+                                            "value": "Oral histories (literary works)"
+                                        }
+                                    ],
+                                    "geogname": [
+                                        {
+                                            "value": "Boston (Mass.) -- Intellectual life -- 20th century."
+                                        }
+                                    ],
+                                    "occupation": [
+                                        {
+                                            "value": "Fulbright scholars."
+                                        }
+                                    ],
+                                    "subject": [
+                                        {
+                                            "value": "Irish American women -- History -- 19th century."
+                                        }
+                                    ]
+                                }
+                            ],
+                            "custodhist": [
+                                {
+                                    "id": "aspace_c7910bb4048953951f92b21d61c08e6a",
+                                    "head": {
+                                        "value": "Custodial History"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "Level 3 This is the Custodial History note."
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "did": {
+                                "physdesc": [
+                                    {
+                                        "value": "\u003cspan class=\"ead-extent\"\u003e12 Linear Feet\u003c/span\u003e\u003cspan class=\"ead-extent\"\u003ein 24 record cartons, 1 manuscript box, and 1 flat file folder\u003c/span\u003e\u003cspan class=\"ead-physfacet\"\u003eHopefully perfectly this is correct\u003c/span\u003e\u003cspan class=\"ead-dimensions\"\u003e12\" x 12\"\u003c/span\u003e",
+                                        "altrender": "whole",
+                                        "extent": [
+                                            {
+                                                "value": "12 Linear Feet",
+                                                "altrender": "materialtype spaceoccupied"
+                                            },
+                                            {
+                                                "value": "in 24 record cartons, 1 manuscript box, and 1 flat file folder",
+                                                "altrender": "carrier"
+                                            }
+                                        ],
+                                        "dimensions": {
+                                            "value": "12\" x 12\""
+                                        },
+                                        "physfacet": {
+                                            "value": "Hopefully perfectly this is correct"
+                                        }
+                                    },
+                                    {
+                                        "value": "Level 3 This is the Physical Description note.",
+                                        "id": "aspace_ad2690d144d7a56a4753497bf80c043b",
+                                        "label": "Physical Description"
+                                    }
+                                ],
+                                "abstract": [
+                                    {
+                                        "value": "Level 3 This is the \u003cspan class=\"ead-emph ead-emph-italic\"\u003eAbstract\u003c/span\u003e. It has a \u003cspan class=\"ead-title\"\u003e\u003cspan class=\"ead-emph ead-emph-bold\"\u003ebold \u003c/span\u003etitle\u003c/span\u003e in it.",
+                                        "id": "aspace_b96a3528d042efb6eb39fc9ee28012f7",
+                                        "title": [
+                                            {
+                                                "value": "\u003cspan class=\"ead-emph ead-emph-bold\"\u003ebold \u003c/span\u003etitle",
+                                                "render": "bold",
+                                                "source": "DACS",
+                                                "type": "book"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "container": [
+                                    {
+                                        "value": "1",
+                                        "altrender": "Record carton",
+                                        "id": "aspace_b5536d690c48c6b42f3faa9fe07082d1",
+                                        "label": "mixed materials",
+                                        "type": "box"
+                                    },
+                                    {
+                                        "value": "1",
+                                        "id": "aspace_8a79b91fe93c7f65091573245ae4c7a2",
+                                        "parent": "aspace_b5536d690c48c6b42f3faa9fe07082d1",
+                                        "type": "folder"
+                                    }
+                                ],
+                                "dao": [
+                                    {
+                                        "actuate": "onRequest",
+                                        "href": "https://hdl.handle.net/2333.1/34tmpk87",
+                                        "role": "video-service",
+                                        "show": "new",
+                                        "title": "This is a digital object",
+                                        "type": "simple",
+                                        "daodesc": {
+                                            "p": [
+                                                {
+                                                    "value": "This is a digital object"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "daogrp": [
+                                    {
+                                        "title": "Archived website of Julie Kathryn",
+                                        "type": "extended",
+                                        "daodesc": {
+                                            "p": [
+                                                {
+                                                    "value": "Archived website of Julie Kathryn"
+                                                }
+                                            ]
+                                        },
+                                        "daoloc": [
+                                            {
+                                                "href": "https://wayback.archive-it.org/9900/*/http://www.iamsnowangel.com",
+                                                "role": "external-link",
+                                                "title": "Archived website of Julie Kathryn",
+                                                "type": "locator"
+                                            },
+                                            {
+                                                "href": "https://wayback.archive-it.org/4049/*/http://www.iamsnowangel.com",
+                                                "role": "external-link",
+                                                "title": "Archived website of Julie Kathryn",
+                                                "type": "locator"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "langmaterial": [
+                                    {
+                                        "value": "Level 3 \u003cspan class=\"ead-emph ead-emph-italic\"\u003eMaterials\u003c/span\u003e are in \u003cspan class=\"ead-language\"\u003eEnglish\u003c/span\u003e.",
+                                        "id": "aspace_1676961983c252b748ee5d2ed7bce91c",
+                                        "language": [
+                                            "English"
+                                        ]
+                                    }
+                                ],
+                                "materialspec": [
+                                    {
+                                        "id": "aspace_90c738fbc387b6372a896966a814da87",
+                                        "children": [
+                                            {
+                                                "name": "div",
+                                                "value": {
+                                                    "value": "Level 3 This is the Materials Specific Details note."
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "origination": [
+                                    {
+                                        "label": "Creator",
+                                        "corpname": [
+                                            {
+                                                "value": "9 to 5, National Association of Working Women (U.S.)"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "label": "Creator",
+                                        "famname": [
+                                            {
+                                                "value": "Chen family"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "label": "Creator",
+                                        "persname": [
+                                            {
+                                                "value": "Adams, B. O."
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "physloc": [
+                                    {
+                                        "value": "Level 3 This is the Physical Location note.",
+                                        "id": "aspace_afd9ea8072f07c5f9bcce1d4a37d1b69"
+                                    },
+                                    {
+                                        "value": "Box 152",
+                                        "id": "aspace_0790e3e9da2aa63ac821c43c3823a5ea"
+                                    }
+                                ],
+                                "unitdate": [
+                                    {
+                                        "value": "2021",
+                                        "type": "inclusive",
+                                        "normal": "2021/2021"
+                                    }
+                                ],
+                                "unitid": "mos_2021_3",
+                                "unittitle": {
+                                    "value": "\u003cspan class=\"ead-emph ead-emph-italic\"\u003eLevel 3\u003c/span\u003e Series I. \u003cspan class=\"ead-persname\"\u003eMegan O'Shea\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e on \u003cspan class=\"ead-corpname\"\u003eNew York University\u003c/span\u003e Here is a \u003cspan class=\"ead-title\"\u003etitle\u003c/span\u003e",
+                                    "corpname": [
+                                        {
+                                            "value": "New York University"
+                                        }
+                                    ],
+                                    "name": [
+                                        {
+                                            "value": "Rolodex"
+                                        }
+                                    ],
+                                    "persname": [
+                                        {
+                                            "value": "Megan O'Shea"
+                                        }
+                                    ],
+                                    "title": [
+                                        {
+                                            "value": "title"
+                                        }
+                                    ]
+                                }
+                            },
+                            "fileplan": [
+                                {
+                                    "id": "aspace_3a7edd9aa5f5261303082c6cd68b21fb",
+                                    "head": {
+                                        "value": "File Plan"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "Level 3 This is the File Plan."
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "index": [
+                                {
+                                    "id": "aspace_abe974fea759a049d62f70ee41835af4",
+                                    "head": {
+                                        "value": "Index head"
+                                    },
+                                    "indexentry": [
+                                        {
+                                            "corpname": [
+                                                {
+                                                    "value": "Level 3 Index item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "p": [
+                                        {
+                                            "value": "Level 3 This is the Index."
+                                        }
+                                    ]
+                                }
+                            ],
+                            "odd": [
+                                {
+                                    "id": "aspace_65945cf78ff0356fdf7b1561e062f16d",
+                                    "head": {
+                                        "value": "General"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "This is the Level 3 General note. \u003cspan class=\"ead-address\"\u003e \u003cspan class=\"ead-addressline\"\u003eElmer Holmes Bobst Library\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003e70 Washington Square South\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003e2nd Floor\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003eNew York, NY 10012\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003especial.collections@nyu.edu\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003eURL: \u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e\u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-abbr\"\u003eALS\u003c/span\u003e \u003cspan class=\"ead-archref\"\u003e \u003ca class=\"ead-extref\" href=\"http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/\" target=\"new\"\u003eThe Sally Belfrage Papers (TAM 189)\u003c/a\u003e\u003c/span\u003e \u003cspan class=\"ead-bibref\"\u003e\u003cspan class=\"ead-emph ead-emph-bold\"\u003eArdouin, Charles Nicholas Celigny\u003c/span\u003e. \u003cspan class=\"ead-title\"\u003eEssais sur l'histoire d'Haiti\u003c/span\u003e. Port-au-Prince, 1865.\u003c/span\u003e \u003cspan class=\"ead-blockquote\"\u003e \u003cspan class=\"ead-p\"\u003eNo doubt the estate has exerted a tremendous influence on the development of my character. One may walk for an hour without glimpsing another soul, which has taught me to love tranquility.\u003c/span\u003e \u003c/span\u003e\u003cbr\u003e \u003cspan class=\"ead-corpname\"\u003eTamiment Library\u003c/span\u003e \u003cspan class=\"ead-date\"\u003eMarch 2021\u003c/span\u003e \u003cspan class=\"ead-list\"\u003e \u003cspan class=\"ead-listhead\"\u003e \u003cspan class=\"ead-head01\"\u003eAbbreviation\u003c/span\u003e \u003cspan class=\"ead-head02\"\u003eExpansion\u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-defitem\"\u003e \u003cspan class=\"ead-label\"\u003eMIT\u003c/span\u003e \u003cspan class=\"ead-item\"\u003eMassachusetts Institute of Technology\u003c/span\u003e \u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e \u003cspan class=\"ead-list\"\u003e \u003cspan class=\"ead-defitem\"\u003e \u003cspan class=\"ead-label\"\u003eMIT\u003c/span\u003e \u003cspan class=\"ead-item\"\u003eMassachusetts Institute of Technology\u003c/span\u003e \u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e",
+                                                "abbr": [
+                                                    "ALS"
+                                                ],
+                                                "address": [
+                                                    {
+                                                        "addressline": [
+                                                            {
+                                                                "value": "Elmer Holmes Bobst Library"
+                                                            },
+                                                            {
+                                                                "value": "70 Washington Square South"
+                                                            },
+                                                            {
+                                                                "value": "2nd Floor"
+                                                            },
+                                                            {
+                                                                "value": "New York, NY 10012"
+                                                            },
+                                                            {
+                                                                "value": "special.collections@nyu.edu"
+                                                            },
+                                                            {
+                                                                "value": "URL: \u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e",
+                                                                "extptr": [
+                                                                    {
+                                                                        "href": "http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/",
+                                                                        "show": "new",
+                                                                        "title": "http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/",
+                                                                        "type": "simple"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "archref": [
+                                                    {
+                                                        "value": "\u003ca class=\"ead-extref\" href=\"http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/\" target=\"new\"\u003eThe Sally Belfrage Papers (TAM 189)\u003c/a\u003e"
+                                                    }
+                                                ],
+                                                "bibref": [
+                                                    {
+                                                        "value": "\u003cspan class=\"ead-emph ead-emph-bold\"\u003eArdouin, Charles Nicholas Celigny\u003c/span\u003e. \u003cspan class=\"ead-title\"\u003eEssais sur l'histoire d'Haiti\u003c/span\u003e. Port-au-Prince, 1865.",
+                                                        "title": [
+                                                            {
+                                                                "value": "Essais sur l'histoire d'Haiti",
+                                                                "render": "italic"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "corpname": [
+                                                    {
+                                                        "value": "Tamiment Library"
+                                                    }
+                                                ],
+                                                "date": [
+                                                    {
+                                                        "value": "March 2021",
+                                                        "type": "creation"
+                                                    }
+                                                ],
+                                                "genreform": [
+                                                    "Oral histories (literary works)",
+                                                    "Oral histories (literary works)"
+                                                ],
+                                                "list": [
+                                                    {
+                                                        "numeration": "arabic",
+                                                        "type": "deflist",
+                                                        "defitem": [
+                                                            {
+                                                                "item": [
+                                                                    {
+                                                                        "value": "Massachusetts Institute of Technology"
+                                                                    }
+                                                                ],
+                                                                "label": "MIT"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "deflist",
+                                                        "defitem": [
+                                                            {
+                                                                "item": [
+                                                                    {
+                                                                        "value": "Massachusetts Institute of Technology"
+                                                                    }
+                                                                ],
+                                                                "label": "MIT"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "name": [
+                                                    {
+                                                        "value": "Rolodex"
+                                                    },
+                                                    {
+                                                        "value": "Rolodex"
+                                                    }
+                                                ],
+                                                "num": [
+                                                    {
+                                                        "value": "MOS.2021",
+                                                        "type": "collection"
+                                                    },
+                                                    {
+                                                        "value": "MOS.2021",
+                                                        "type": "collection"
+                                                    }
+                                                ],
+                                                "occupation": [
+                                                    "Fulbright scholars.",
+                                                    "Fulbright scholars."
+                                                ],
+                                                "subject": [
+                                                    "Irish American women -- History -- 19th century.",
+                                                    "Irish American women -- History -- 19th century."
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "name": "list",
+                                            "value": {
+                                                "type": "deflist",
+                                                "defitem": [
+                                                    {
+                                                        "item": [
+                                                            {
+                                                                "value": "Massachusetts Institute of Technology"
+                                                            }
+                                                        ],
+                                                        "label": "MIT"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "\u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e",
+                                                "genreform": [
+                                                    "Oral histories (literary works)"
+                                                ],
+                                                "name": [
+                                                    {
+                                                        "value": "Rolodex"
+                                                    }
+                                                ],
+                                                "num": [
+                                                    {
+                                                        "value": "MOS.2021",
+                                                        "type": "collection"
+                                                    }
+                                                ],
+                                                "occupation": [
+                                                    "Fulbright scholars."
+                                                ],
+                                                "subject": [
+                                                    "Irish American women -- History -- 19th century."
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "name": "list",
+                                            "value": {
+                                                "type": "deflist",
+                                                "defitem": [
+                                                    {
+                                                        "item": [
+                                                            {
+                                                                "value": "Massachusetts Institute of Technology"
+                                                            }
+                                                        ],
+                                                        "label": "MIT"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "\u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e",
+                                                "genreform": [
+                                                    "Oral histories (literary works)"
+                                                ],
+                                                "name": [
+                                                    {
+                                                        "value": "Rolodex"
+                                                    }
+                                                ],
+                                                "num": [
+                                                    {
+                                                        "value": "MOS.2021",
+                                                        "type": "collection"
+                                                    }
+                                                ],
+                                                "occupation": [
+                                                    "Fulbright scholars."
+                                                ],
+                                                "subject": [
+                                                    "Irish American women -- History -- 19th century."
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "otherfindaid": [
+                                {
+                                    "id": "aspace_f752b0a547efbc69593268b979035730",
+                                    "head": {
+                                        "value": "Other Finding Aids"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "Level 3 This is the Other Finding Aids note."
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "originalsloc": [
+                                {
+                                    "id": "aspace_63787a39fe65c3530f57167e2d2b3479",
+                                    "head": {
+                                        "value": "Existence and Location of Originals"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "Level 3 This is the Existence and Location of Originals note."
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "phystech": [
+                                {
+                                    "id": "aspace_9457c04ac099016322bacfa5e3f8c134",
+                                    "head": {
+                                        "value": "Physical Characteristics and Technical Requirements"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "Level 3 This is the Physical Characteristics and Technical Requirements note."
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "prefercite": [
+                                {
+                                    "id": "aspace_9a9f8b796bc9b4ae0b177cdc7f4b26e5",
+                                    "head": {
+                                        "value": "Preferred Citation"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "Level 3 This is the Preferred Citation note."
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "processinfo": [
+                                {
+                                    "id": "aspace_08acbdeac7c85e295f622c726791b736",
+                                    "head": {
+                                        "value": "Processing Information"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "Level 3 This is the Processing Information note."
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "relatedmaterial": [
+                                {
+                                    "id": "aspace_800b52132f1e955130a00bfa732ab9e6",
+                                    "head": {
+                                        "value": "Related Materials"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "Level 3 This is the Related Materials note."
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "scopecontent": [
+                                {
+                                    "id": "aspace_5a26daae9c40e27a40cfb1ab51f8d06b",
+                                    "head": {
+                                        "value": "Scope and Contents"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "Level 3 This is the Scope and Content note."
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "separatedmaterial": [
+                                {
+                                    "id": "aspace_c69ecb09a1481b003fdd5772eaafc419",
+                                    "head": {
+                                        "value": "Separated Materials"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "Level 3 This is the Separated Materials note. \u003cspan class=\"ead-archref\"\u003e\u003cspan class=\"ead-physloc\"\u003eBox 152\u003c/span\u003e\u003c/span\u003e",
+                                                "archref": [
+                                                    {
+                                                        "value": "\u003cspan class=\"ead-physloc\"\u003eBox 152\u003c/span\u003e",
+                                                        "physloc": [
+                                                            {
+                                                                "value": "Box 152"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "userestrict": [
+                                {
+                                    "id": "aspace_17b8b10cf5a81a95c0b8cf6e7eefb11c",
+                                    "head": {
+                                        "value": "Conditions Governing Use"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "Level 3 This is the Conditions Governing Use note."
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "aspace_b3c9c88449f4f8e8a4bf801cf619517b",
+                            "level": "item",
+                            "did": {
+                                "container": [
+                                    {
+                                        "value": "1",
+                                        "altrender": "Record carton",
+                                        "id": "aspace_aaeb8f9710e138489515eea6a13b5e2a",
+                                        "label": "mixed materials",
+                                        "type": "box"
+                                    }
+                                ],
+                                "dao": [
+                                    {
+                                        "actuate": "onRequest",
+                                        "href": "https://aeon.library.nyu.edu/remoteauth/aeon.dll?Logon\u0026Action=10\u0026Form=31\u0026Value=http://dlib.nyu.edu/findingaids/ead/tamwag/mos_2021.xml\u0026view=xml",
+                                        "role": "electronic-records-service",
+                                        "show": "new",
+                                        "title": "This is a digital object",
+                                        "type": "simple",
+                                        "daodesc": {
+                                            "p": [
+                                                {
+                                                    "value": "This is a digital object"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "daogrp": [
+                                    {
+                                        "title": "Archived website of Julie Kathryn",
+                                        "type": "extended",
+                                        "daodesc": {
+                                            "p": [
+                                                {
+                                                    "value": "Archived website of Julie Kathryn"
+                                                }
+                                            ]
+                                        },
+                                        "daoloc": [
+                                            {
+                                                "href": "https://wayback.archive-it.org/9900/*/http://www.iamsnowangel.com",
+                                                "role": "external-link",
+                                                "title": "Archived website of Julie Kathryn",
+                                                "type": "locator"
+                                            },
+                                            {
+                                                "href": "https://wayback.archive-it.org/4049/*/http://www.iamsnowangel.com",
+                                                "role": "external-link",
+                                                "title": "Archived website of Julie Kathryn",
+                                                "type": "locator"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "physloc": [
+                                    {
+                                        "value": "Box 152",
+                                        "id": "aspace_a1505cc79395c354f713ced482260ea0"
+                                    },
+                                    {
+                                        "value": "Box 152",
+                                        "id": "aspace_68b441337b28f7782012a4e85066959d"
+                                    },
+                                    {
+                                        "value": "Box 152",
+                                        "id": "aspace_84f90467828627064ca55ffc7f1e8336"
+                                    }
+                                ],
+                                "unittitle": {
+                                    "value": "\u003cspan class=\"ead-emph ead-emph-bold\"\u003eThis is an item\u003c/span\u003e Here is a \u003cspan class=\"ead-title\"\u003etitle\u003c/span\u003e. There is also a \u003cspan class=\"ead-name\"\u003ename\u003c/span\u003e.",
+                                    "name": [
+                                        {
+                                            "value": "name"
+                                        }
+                                    ],
+                                    "title": [
+                                        {
+                                            "value": "title"
+                                        }
+                                    ]
+                                }
+                            },
+                            "separatedmaterial": [
+                                {
+                                    "id": "aspace_00dd4ebd926cd579f1fd8739f3f4ac5b",
+                                    "head": {
+                                        "value": "Separated Materials"
+                                    },
+                                    "children": [
+                                        {
+                                            "name": "p",
+                                            "value": {
+                                                "value": "\u003cspan class=\"ead-archref\"\u003e\u003cspan class=\"ead-physloc\"\u003eBox 152\u003c/span\u003e\u003c/span\u003e",
+                                                "archref": [
+                                                    {
+                                                        "value": "\u003cspan class=\"ead-physloc\"\u003eBox 152\u003c/span\u003e",
+                                                        "physloc": [
+                                                            {
+                                                                "value": "Box 152"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "aspace_319857d7c2d36228d3335abb88396b2b",
+                            "level": "otherlevel",
+                            "otherlevel": "website",
+                            "did": {
+                                "daogrp": [
+                                    {
+                                        "title": "Archived website of Julie Kathryn",
+                                        "type": "extended",
+                                        "daodesc": {
+                                            "p": [
+                                                {
+                                                    "value": "Archived website of Julie Kathryn"
+                                                }
+                                            ]
+                                        },
+                                        "daoloc": [
+                                            {
+                                                "href": "https://wayback.archive-it.org/9900/*/http://www.iamsnowangel.com",
+                                                "role": "external-link",
+                                                "title": "Archived website of Julie Kathryn",
+                                                "type": "locator"
+                                            },
+                                            {
+                                                "href": "https://wayback.archive-it.org/4049/*/http://www.iamsnowangel.com",
+                                                "role": "external-link",
+                                                "title": "Archived website of Julie Kathryn",
+                                                "type": "locator"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "unitdate": [
+                                    {
+                                        "value": "1981-09-02",
+                                        "normal": "1981-09-02/1981-09-02"
+                                    }
+                                ],
+                                "unittitle": {
+                                    "value": "The Dreaded Other Level"
+                                }
+                            }
+                        }
+                    ],
+                    "controlaccess": [
+                        {
+                            "corpname": [
+                                {
+                                    "value": "Tamiment Library"
+                                }
+                            ],
+                            "famname": [
+                                {
+                                    "value": "Belfrage family"
+                                }
+                            ],
+                            "function": [
+                                {
+                                    "value": "War Powers Conference"
+                                }
+                            ],
+                            "genreform": [
+                                {
+                                    "value": "Oral histories (literary works)"
+                                }
+                            ],
+                            "geogname": [
+                                {
+                                    "value": "Boston (Mass.) -- Intellectual life -- 20th century."
+                                }
+                            ],
+                            "occupation": [
+                                {
+                                    "value": "Fulbright scholars."
+                                }
+                            ],
+                            "subject": [
+                                {
+                                    "value": "Irish American women -- History -- 19th century."
+                                }
+                            ]
+                        }
+                    ],
+                    "custodhist": [
+                        {
+                            "id": "aspace_7833813cd40de517441d95dd27e383f3",
+                            "head": {
+                                "value": "Custodial History"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "Level 2 This is the Custodial History note."
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "did": {
+                        "physdesc": [
+                            {
+                                "value": "\u003cspan class=\"ead-extent\"\u003e23 Linear Feet\u003c/span\u003e\u003cspan class=\"ead-extent\"\u003ein 24 record cartons, 1 manuscript box, and 1 flat file folder\u003c/span\u003e\u003cspan class=\"ead-physfacet\"\u003ehandwritten notes\u003c/span\u003e\u003cspan class=\"ead-dimensions\"\u003e24\" x 24\"\u003c/span\u003e",
+                                "altrender": "whole",
+                                "extent": [
+                                    {
+                                        "value": "23 Linear Feet",
+                                        "altrender": "materialtype spaceoccupied"
+                                    },
+                                    {
+                                        "value": "in 24 record cartons, 1 manuscript box, and 1 flat file folder",
+                                        "altrender": "carrier"
+                                    }
+                                ],
+                                "dimensions": {
+                                    "value": "24\" x 24\""
+                                },
+                                "physfacet": {
+                                    "value": "handwritten notes"
+                                }
+                            }
+                        ],
+                        "abstract": [
+                            {
+                                "value": "Level 2 This is the \u003cspan class=\"ead-emph ead-emph-italic\"\u003eabstract\u003c/span\u003e. It has a \u003cspan class=\"ead-title\"\u003e\u003cspan class=\"ead-emph ead-emph-bold\"\u003ebold\u003c/span\u003etitle \u003c/span\u003e in it.",
+                                "id": "aspace_fb8fc30fbb1f790bf2719a30511c5040",
+                                "title": [
+                                    {
+                                        "value": "\u003cspan class=\"ead-emph ead-emph-bold\"\u003ebold\u003c/span\u003etitle",
+                                        "render": "bold",
+                                        "source": "DACS",
+                                        "type": "book"
+                                    }
+                                ]
+                            }
+                        ],
+                        "container": [
+                            {
+                                "value": "1",
+                                "altrender": "Record carton",
+                                "id": "aspace_97aeb165b6f69d0120e9d7ce67faac18",
+                                "label": "mixed materials",
+                                "type": "box"
+                            },
+                            {
+                                "value": "1",
+                                "id": "aspace_3e378514974315119d35e619a686c6d4",
+                                "parent": "aspace_97aeb165b6f69d0120e9d7ce67faac18",
+                                "type": "folder"
+                            }
+                        ],
+                        "dao": [
+                            {
+                                "actuate": "onRequest",
+                                "href": "https://hdl.handle.net/2333.1/7h44j74d",
+                                "role": "audio-service",
+                                "show": "new",
+                                "title": "This is a digital object",
+                                "type": "simple",
+                                "daodesc": {
+                                    "p": [
+                                        {
+                                            "value": "This is a digital object"
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        "daogrp": [
+                            {
+                                "title": "Archived website of Julie Kathryn",
+                                "type": "extended",
+                                "daodesc": {
+                                    "p": [
+                                        {
+                                            "value": "Archived website of Julie Kathryn"
+                                        }
+                                    ]
+                                },
+                                "daoloc": [
+                                    {
+                                        "href": "https://wayback.archive-it.org/9900/*/http://www.iamsnowangel.com",
+                                        "role": "external-link",
+                                        "title": "Archived website of Julie Kathryn",
+                                        "type": "locator"
+                                    },
+                                    {
+                                        "href": "https://wayback.archive-it.org/4049/*/http://www.iamsnowangel.com",
+                                        "role": "external-link",
+                                        "title": "Archived website of Julie Kathryn",
+                                        "type": "locator"
+                                    }
+                                ]
+                            }
+                        ],
+                        "langmaterial": [
+                            {
+                                "value": "Level 2 \u003cspan class=\"ead-emph ead-emph-italic\"\u003eMaterials\u003c/span\u003e are in \u003cspan class=\"ead-language\"\u003eEnglish\u003c/span\u003e.",
+                                "id": "aspace_d346225d0e8db11008a962db2f193951",
+                                "language": [
+                                    "English"
+                                ]
+                            }
+                        ],
+                        "materialspec": [
+                            {
+                                "id": "aspace_8ec8f4ba4cc227c264b552803da8dd5b",
+                                "children": [
+                                    {
+                                        "name": "div",
+                                        "value": {
+                                            "value": "Level 2 This is the Materials Specific Details."
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        "origination": [
+                            {
+                                "label": "Creator",
+                                "corpname": [
+                                    {
+                                        "value": "80 Washington Square East Galleries"
+                                    }
+                                ]
+                            },
+                            {
+                                "label": "Creator",
+                                "famname": [
+                                    {
+                                        "value": "Blaustein Family"
+                                    }
+                                ]
+                            },
+                            {
+                                "label": "Creator",
+                                "persname": [
+                                    {
+                                        "value": "Aaron, Florence"
+                                    }
+                                ]
+                            }
+                        ],
+                        "physloc": [
+                            {
+                                "value": "Level 2 This is the Physical Location note.",
+                                "id": "aspace_ad1c900356662423adac4e02c50f167e"
+                            },
+                            {
+                                "value": "Box 152",
+                                "id": "aspace_f3cdfc7ba5bcc54f1f0ff7893f0ae71b"
+                            }
+                        ],
+                        "unitdate": [
+                            {
+                                "value": "2015-2016",
+                                "type": "inclusive",
+                                "normal": "2015/2016"
+                            }
+                        ],
+                        "unitid": "mos_2021_2",
+                        "unittitle": {
+                            "value": "\u003cspan class=\"ead-emph ead-emph-italic\"\u003eLevel 2\u003c/span\u003e Series I. \u003cspan class=\"ead-persname\"\u003eMegan O'Shea\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e on \u003cspan class=\"ead-corpname\"\u003eNew York University\u003c/span\u003e Here is a \u003cspan class=\"ead-title\"\u003etitle\u003c/span\u003e",
+                            "corpname": [
+                                {
+                                    "value": "New York University"
+                                }
+                            ],
+                            "name": [
+                                {
+                                    "value": "Rolodex"
+                                }
+                            ],
+                            "persname": [
+                                {
+                                    "value": "Megan O'Shea"
+                                }
+                            ],
+                            "title": [
+                                {
+                                    "value": "title"
+                                }
+                            ]
+                        }
+                    },
+                    "fileplan": [
+                        {
+                            "id": "aspace_9d92cfbb19d3ab2eae98b3509bb13eb6",
+                            "head": {
+                                "value": "File Plan"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "Level 2 This is the File Plan."
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "index": [
+                        {
+                            "id": "aspace_4793fb5ebba78bde4487e0c1b06e788a",
+                            "head": {
+                                "value": "This is the Index head."
+                            },
+                            "indexentry": [
+                                {
+                                    "corpname": [
+                                        {
+                                            "value": "Level 2 Index term 1"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": [
+                                        {
+                                            "value": "Level 2 Index term 2"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "subject": [
+                                        "Level 2 Index term 3"
+                                    ]
+                                }
+                            ],
+                            "p": [
+                                {
+                                    "value": "Level 2 This is the Index."
+                                }
+                            ]
+                        }
+                    ],
+                    "odd": [
+                        {
+                            "id": "aspace_14d8b5cc06e376f794ada956e2dc3d1a",
+                            "head": {
+                                "value": "General"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "This is the Level 2 General note. \u003cspan class=\"ead-address\"\u003e \u003cspan class=\"ead-addressline\"\u003eElmer Holmes Bobst Library\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003e70 Washington Square South\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003e2nd Floor\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003eNew York, NY 10012\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003especial.collections@nyu.edu\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003eURL: \u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e\u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-abbr\"\u003eALS\u003c/span\u003e \u003cspan class=\"ead-archref\"\u003e \u003ca class=\"ead-extref\" href=\"http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/\" target=\"new\"\u003eThe Sally Belfrage Papers (TAM 189)\u003c/a\u003e\u003c/span\u003e \u003cspan class=\"ead-bibref\"\u003e\u003cspan class=\"ead-emph ead-emph-bold\"\u003eArdouin, Charles Nicholas Celigny\u003c/span\u003e. \u003cspan class=\"ead-title\"\u003eEssais sur l'histoire d'Haiti\u003c/span\u003e. Port-au-Prince, 1865.\u003c/span\u003e \u003cspan class=\"ead-blockquote\"\u003e \u003cspan class=\"ead-p\"\u003eNo doubt the estate has exerted a tremendous influence on the development of my character. One may walk for an hour without glimpsing another soul, which has taught me to love tranquility.\u003c/span\u003e \u003c/span\u003e\u003cbr\u003e \u003cspan class=\"ead-corpname\"\u003eTamiment Library\u003c/span\u003e \u003cspan class=\"ead-date\"\u003eMarch 2021\u003c/span\u003e \u003cspan class=\"ead-list\"\u003e \u003cspan class=\"ead-listhead\"\u003e \u003cspan class=\"ead-head01\"\u003eAbbreviation\u003c/span\u003e \u003cspan class=\"ead-head02\"\u003eExpansion\u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-defitem\"\u003e \u003cspan class=\"ead-label\"\u003eMIT\u003c/span\u003e \u003cspan class=\"ead-item\"\u003eMassachusetts Institute of Technology\u003c/span\u003e \u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e \u003cspan class=\"ead-list\"\u003e \u003cspan class=\"ead-defitem\"\u003e \u003cspan class=\"ead-label\"\u003eMIT\u003c/span\u003e \u003cspan class=\"ead-item\"\u003eMassachusetts Institute of Technology\u003c/span\u003e \u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e",
+                                        "abbr": [
+                                            "ALS"
+                                        ],
+                                        "address": [
+                                            {
+                                                "addressline": [
+                                                    {
+                                                        "value": "Elmer Holmes Bobst Library"
+                                                    },
+                                                    {
+                                                        "value": "70 Washington Square South"
+                                                    },
+                                                    {
+                                                        "value": "2nd Floor"
+                                                    },
+                                                    {
+                                                        "value": "New York, NY 10012"
+                                                    },
+                                                    {
+                                                        "value": "special.collections@nyu.edu"
+                                                    },
+                                                    {
+                                                        "value": "URL: \u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e",
+                                                        "extptr": [
+                                                            {
+                                                                "href": "http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/",
+                                                                "show": "new",
+                                                                "title": "http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/",
+                                                                "type": "simple"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "archref": [
+                                            {
+                                                "value": "\u003ca class=\"ead-extref\" href=\"http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/\" target=\"new\"\u003eThe Sally Belfrage Papers (TAM 189)\u003c/a\u003e"
+                                            }
+                                        ],
+                                        "bibref": [
+                                            {
+                                                "value": "\u003cspan class=\"ead-emph ead-emph-bold\"\u003eArdouin, Charles Nicholas Celigny\u003c/span\u003e. \u003cspan class=\"ead-title\"\u003eEssais sur l'histoire d'Haiti\u003c/span\u003e. Port-au-Prince, 1865.",
+                                                "title": [
+                                                    {
+                                                        "value": "Essais sur l'histoire d'Haiti",
+                                                        "render": "italic"
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "corpname": [
+                                            {
+                                                "value": "Tamiment Library"
+                                            }
+                                        ],
+                                        "date": [
+                                            {
+                                                "value": "March 2021",
+                                                "type": "creation"
+                                            }
+                                        ],
+                                        "genreform": [
+                                            "Oral histories (literary works)",
+                                            "Oral histories (literary works)"
+                                        ],
+                                        "list": [
+                                            {
+                                                "numeration": "arabic",
+                                                "type": "deflist",
+                                                "defitem": [
+                                                    {
+                                                        "item": [
+                                                            {
+                                                                "value": "Massachusetts Institute of Technology"
+                                                            }
+                                                        ],
+                                                        "label": "MIT"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "deflist",
+                                                "defitem": [
+                                                    {
+                                                        "item": [
+                                                            {
+                                                                "value": "Massachusetts Institute of Technology"
+                                                            }
+                                                        ],
+                                                        "label": "MIT"
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "name": [
+                                            {
+                                                "value": "Rolodex"
+                                            },
+                                            {
+                                                "value": "Rolodex"
+                                            }
+                                        ],
+                                        "num": [
+                                            {
+                                                "value": "MOS.2021",
+                                                "type": "collection"
+                                            },
+                                            {
+                                                "value": "MOS.2021",
+                                                "type": "collection"
+                                            }
+                                        ],
+                                        "occupation": [
+                                            "Fulbright scholars.",
+                                            "Fulbright scholars."
+                                        ],
+                                        "subject": [
+                                            "Irish American women -- History -- 19th century.",
+                                            "Irish American women -- History -- 19th century."
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "list",
+                                    "value": {
+                                        "type": "deflist",
+                                        "defitem": [
+                                            {
+                                                "item": [
+                                                    {
+                                                        "value": "Massachusetts Institute of Technology"
+                                                    }
+                                                ],
+                                                "label": "MIT"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "\u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e",
+                                        "genreform": [
+                                            "Oral histories (literary works)"
+                                        ],
+                                        "name": [
+                                            {
+                                                "value": "Rolodex"
+                                            }
+                                        ],
+                                        "num": [
+                                            {
+                                                "value": "MOS.2021",
+                                                "type": "collection"
+                                            }
+                                        ],
+                                        "occupation": [
+                                            "Fulbright scholars."
+                                        ],
+                                        "subject": [
+                                            "Irish American women -- History -- 19th century."
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "list",
+                                    "value": {
+                                        "type": "deflist",
+                                        "defitem": [
+                                            {
+                                                "item": [
+                                                    {
+                                                        "value": "Massachusetts Institute of Technology"
+                                                    }
+                                                ],
+                                                "label": "MIT"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "\u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e",
+                                        "genreform": [
+                                            "Oral histories (literary works)"
+                                        ],
+                                        "name": [
+                                            {
+                                                "value": "Rolodex"
+                                            }
+                                        ],
+                                        "num": [
+                                            {
+                                                "value": "MOS.2021",
+                                                "type": "collection"
+                                            }
+                                        ],
+                                        "occupation": [
+                                            "Fulbright scholars."
+                                        ],
+                                        "subject": [
+                                            "Irish American women -- History -- 19th century."
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "otherfindaid": [
+                        {
+                            "id": "aspace_9724a3d4aa1bf9f723d0abf10571cf3f",
+                            "head": {
+                                "value": "Other Finding Aids"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "Level 2 This is the Other Finding Aids note."
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "originalsloc": [
+                        {
+                            "id": "aspace_a1b5fbc79910c44817488d250729a686",
+                            "head": {
+                                "value": "Existence and Location of Originals"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "Level 2 This is the Existence and Location of Originals note."
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "phystech": [
+                        {
+                            "id": "aspace_7e8552be007d9fc35331a59e0a831f5a",
+                            "head": {
+                                "value": "Physical Characteristics and Technical Requirements"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "Level 2 This is the Physical Characteristics and Technical Requirements note."
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "prefercite": [
+                        {
+                            "id": "aspace_59802249b65517da54ed657385362e5b",
+                            "head": {
+                                "value": "Preferred Citation"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "Level 2 This is the Preferred Citation note."
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "processinfo": [
+                        {
+                            "id": "aspace_703aa9981288e97d16c6e3bd32ca5b22",
+                            "head": {
+                                "value": "Processing Information"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "Level 2 This is the Processing Information note."
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "relatedmaterial": [
+                        {
+                            "id": "aspace_2ed7b9e4dd352111e89a909ba78dfca4",
+                            "head": {
+                                "value": "Related Materials"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "Level 2 This is the Related Materials note."
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "scopecontent": [
+                        {
+                            "id": "aspace_dfac3eae96d7fc3be099ae7fa8bd22e3",
+                            "head": {
+                                "value": "Scope and Contents"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "Level 2 This is the Scope and Content note."
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "separatedmaterial": [
+                        {
+                            "id": "aspace_f2ccd75f63f83d36ad8222b582035a6b",
+                            "head": {
+                                "value": "Separated Materials"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "Level 2 This is the Separated Materials note. \u003cspan class=\"ead-archref\"\u003e\u003cspan class=\"ead-physloc\"\u003eBox 152\u003c/span\u003e\u003c/span\u003e",
+                                        "archref": [
+                                            {
+                                                "value": "\u003cspan class=\"ead-physloc\"\u003eBox 152\u003c/span\u003e",
+                                                "physloc": [
+                                                    {
+                                                        "value": "Box 152"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "userestrict": [
+                        {
+                            "id": "aspace_2a50b40dffc6e51c474e021a377e8d5c",
+                            "head": {
+                                "value": "Conditions Governing Use"
+                            },
+                            "children": [
+                                {
+                                    "name": "p",
+                                    "value": {
+                                        "value": "Level 2 This is the Conditions Governing Use note."
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "additional-daos",
+                    "level": "series",
+                    "c": [
+                        {
+                            "id": "dao1",
+                            "level": "file",
+                            "did": {
+                                "dao": [
+                                    {
+                                        "actuate": "onRequest",
+                                        "href": "https://hdl.handle.net/2333.1/wm37q0k4",
+                                        "role": "audio-service",
+                                        "show": "new",
+                                        "title": "4th Annual Flaherty Seminar - Tape 1",
+                                        "type": "simple",
+                                        "daodesc": {
+                                            "p": [
+                                                {
+                                                    "value": "4th Annual Flaherty Seminar - Tape 1: August 19, 1958"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "unittitle": {
+                                    "value": "Audio-Service"
+                                }
+                            }
+                        },
+                        {
+                            "id": "dao2",
+                            "level": "file",
+                            "did": {
+                                "dao": [
+                                    {
+                                        "actuate": "onLoad",
+                                        "href": "https://aeon.library.nyu.edu/Logon?Action=10\u0026Form=31\u0026Value=http://dlib.nyu.edu/findingaids/ead/fales/mss_094.xml\u0026view=xml",
+                                        "role": "audio-reading-room",
+                                        "show": "new",
+                                        "title": "Cassettes - America's Disinherited - Commentary by Hacker/Willens -4/14/85",
+                                        "type": "simple",
+                                        "daodesc": {
+                                            "p": [
+                                                {
+                                                    "value": "Cassettes - America's Disinherited - Commentary by Hacker/Willens -4/14/85"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "unittitle": {
+                                    "value": "Audio-Reading-Room"
+                                }
+                            }
+                        },
+                        {
+                            "id": "dao3",
+                            "level": "file",
+                            "did": {
+                                "dao": [
+                                    {
+                                        "actuate": "onRequest",
+                                        "href": "https://hdl.handle.net/2333.1/bnzs7m9t",
+                                        "role": "video-service",
+                                        "show": "new",
+                                        "title": "[1]--Gay USA, Vol. [VIII] Episode No. 4 [Air date: 7/19/1990]",
+                                        "type": "simple",
+                                        "daodesc": {
+                                            "p": [
+                                                {
+                                                    "value": "[1]--Gay USA, Vol. [VIII] Episode No. 4 [Air date: 7/19/1990]: July 1990"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "unittitle": {
+                                    "value": "Video-Service"
+                                }
+                            }
+                        },
+                        {
+                            "id": "dao4",
+                            "level": "file",
+                            "did": {
+                                "dao": [
+                                    {
+                                        "actuate": "onLoad",
+                                        "href": "https://aeon.library.nyu.edu/Logon?Action=10\u0026Form=31\u0026Value=http://dlib.nyu.edu/findingaids/ead/fales/mss_276.xml\u0026view=xml",
+                                        "role": "video-reading-room",
+                                        "show": "new",
+                                        "title": "Herb KO's Corporate Sports - Dub Master",
+                                        "type": "simple",
+                                        "daodesc": {
+                                            "p": [
+                                                {
+                                                    "value": "Herb KO's Corporate Sports - Dub Master"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "unittitle": {
+                                    "value": "Video-Reading-Room"
+                                }
+                            }
+                        },
+                        {
+                            "id": "dao5",
+                            "level": "file",
+                            "did": {
+                                "dao": [
+                                    {
+                                        "actuate": "onRequest",
+                                        "href": "https://hdl.handle.net/2333.1/ttdz0j92",
+                                        "role": "image-service",
+                                        "show": "new",
+                                        "title": "Envelope 1: Caven Point, NJ, 1984 w/Steve Brown",
+                                        "type": "simple",
+                                        "daodesc": {
+                                            "p": [
+                                                {
+                                                    "value": "Envelope 1: Caven Point, NJ, 1984 w/Steve Brown: undated"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "unittitle": {
+                                    "value": "Image-Service"
+                                }
+                            }
+                        },
+                        {
+                            "id": "dao6",
+                            "level": "file",
+                            "did": {
+                                "dao": [
+                                    {
+                                        "actuate": "onLoad",
+                                        "href": "https://wayback.archive-it.org/6129/*/http://www.thefugs.com/",
+                                        "role": "external-link",
+                                        "show": "new",
+                                        "title": "Archived website of the Fugs",
+                                        "type": "simple",
+                                        "daodesc": {
+                                            "p": [
+                                                {
+                                                    "value": "Archived website of the Fugs"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "unittitle": {
+                                    "value": "External-Link"
+                                }
+                            }
+                        },
+                        {
+                            "id": "dao7",
+                            "level": "file",
+                            "did": {
+                                "dao": [
+                                    {
+                                        "actuate": "onLoad",
+                                        "href": "https://aeon.library.nyu.edu/Logon?Action=10\u0026Form=31\u0026Value=%20http://dlib.nyu.edu/findingaids/ead/fales/mss_253.xml\u0026view=xml",
+                                        "role": "electronic-records-reading-room",
+                                        "show": "new",
+                                        "title": "Digital Duets Langland La MaMa",
+                                        "type": "simple",
+                                        "daodesc": {
+                                            "p": [
+                                                {
+                                                    "value": "Digital Duets Langland La MaMa: 2012-"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "unittitle": {
+                                    "value": "Electronic-Records-Reading-Room"
+                                }
+                            }
+                        },
+                        {
+                            "id": "aspace_7c4d41e52826eec1ee0f21625ae73961",
+                            "level": "file",
+                            "did": {
+                                "dao": [
+                                    {
+                                        "actuate": "onRequest",
+                                        "href": "https://hdl.handle.net/2333.1/dfn2z8sk",
+                                        "role": "image-service",
+                                        "show": "new",
+                                        "title": "Three children in the Japanese Gardens: 1984",
+                                        "type": "simple",
+                                        "daodesc": {
+                                            "p": [
+                                                {
+                                                    "value": "Three children in the Japanese Gardens: 1984"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "unittitle": {
+                                    "value": "Image-Service"
+                                }
+                            }
+                        }
+                    ],
+                    "did": {
+                        "unittitle": {
+                            "value": "Series II. Additional Digital Objects"
+                        }
+                    }
+                }
+            ]
+        },
+        "odd": [
+            {
+                "id": "aspace_0c2299264bc16498d16857b8d48c6626",
+                "head": {
+                    "value": "General"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the General note. \u003cspan class=\"ead-address\"\u003e \u003cspan class=\"ead-addressline\"\u003eElmer Holmes Bobst Library\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003e70 Washington Square South\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003e2nd Floor\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003eNew York, NY 10012\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003especial.collections@nyu.edu\u003c/span\u003e \u003cspan class=\"ead-addressline\"\u003eURL: \u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e\u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-abbr\"\u003eALS\u003c/span\u003e \u003cspan class=\"ead-archref\"\u003e \u003ca class=\"ead-extref\" href=\"http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/\" target=\"new\"\u003eThe Sally Belfrage Papers (TAM 189)\u003c/a\u003e\u003c/span\u003e \u003cspan class=\"ead-bibref\"\u003e\u003cspan class=\"ead-emph ead-emph-bold\"\u003eArdouin, Charles Nicholas Celigny\u003c/span\u003e. \u003cspan class=\"ead-title\"\u003eEssais sur l'histoire d'Haiti\u003c/span\u003e. Port-au-Prince, 1865.\u003c/span\u003e \u003cspan class=\"ead-blockquote\"\u003e \u003cspan class=\"ead-p\"\u003eNo doubt the estate has exerted a tremendous influence on the development of my character. One may walk for an hour without glimpsing another soul, which has taught me to love tranquility.\u003c/span\u003e \u003c/span\u003e\u003cbr\u003e \u003cspan class=\"ead-corpname\"\u003eTamiment Library\u003c/span\u003e \u003cspan class=\"ead-date\"\u003eMarch 2021\u003c/span\u003e \u003cspan class=\"ead-list\"\u003e \u003cspan class=\"ead-listhead\"\u003e \u003cspan class=\"ead-head01\"\u003eAbbreviation\u003c/span\u003e \u003cspan class=\"ead-head02\"\u003eExpansion\u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-defitem\"\u003e \u003cspan class=\"ead-label\"\u003eMIT\u003c/span\u003e \u003cspan class=\"ead-item\"\u003eMassachusetts Institute of Technology\u003c/span\u003e \u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-genreform\"\u003eOral histories (literary works)\u003c/span\u003e \u003cspan class=\"ead-name\"\u003eRolodex\u003c/span\u003e \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e \u003cspan class=\"ead-occupation\"\u003eFulbright scholars.\u003c/span\u003e \u003cspan class=\"ead-subject\"\u003eIrish American women -- History -- 19th century.\u003c/span\u003e",
+                            "abbr": [
+                                "ALS"
+                            ],
+                            "address": [
+                                {
+                                    "addressline": [
+                                        {
+                                            "value": "Elmer Holmes Bobst Library"
+                                        },
+                                        {
+                                            "value": "70 Washington Square South"
+                                        },
+                                        {
+                                            "value": "2nd Floor"
+                                        },
+                                        {
+                                            "value": "New York, NY 10012"
+                                        },
+                                        {
+                                            "value": "special.collections@nyu.edu"
+                                        },
+                                        {
+                                            "value": "URL: \u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e",
+                                            "extptr": [
+                                                {
+                                                    "href": "http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/",
+                                                    "show": "new",
+                                                    "title": "http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/",
+                                                    "type": "simple"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "archref": [
+                                {
+                                    "value": "\u003ca class=\"ead-extref\" href=\"http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/\" target=\"new\"\u003eThe Sally Belfrage Papers (TAM 189)\u003c/a\u003e"
+                                }
+                            ],
+                            "bibref": [
+                                {
+                                    "value": "\u003cspan class=\"ead-emph ead-emph-bold\"\u003eArdouin, Charles Nicholas Celigny\u003c/span\u003e. \u003cspan class=\"ead-title\"\u003eEssais sur l'histoire d'Haiti\u003c/span\u003e. Port-au-Prince, 1865.",
+                                    "title": [
+                                        {
+                                            "value": "Essais sur l'histoire d'Haiti",
+                                            "render": "italic"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "corpname": [
+                                {
+                                    "value": "Tamiment Library"
+                                }
+                            ],
+                            "date": [
+                                {
+                                    "value": "March 2021"
+                                }
+                            ],
+                            "genreform": [
+                                "Oral histories (literary works)"
+                            ],
+                            "list": [
+                                {
+                                    "numeration": "arabic",
+                                    "type": "deflist",
+                                    "defitem": [
+                                        {
+                                            "item": [
+                                                {
+                                                    "value": "Massachusetts Institute of Technology"
+                                                }
+                                            ],
+                                            "label": "MIT"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "name": [
+                                {
+                                    "value": "Rolodex"
+                                }
+                            ],
+                            "num": [
+                                {
+                                    "value": "MOS.2021",
+                                    "type": "collection"
+                                }
+                            ],
+                            "occupation": [
+                                "Fulbright scholars."
+                            ],
+                            "subject": [
+                                "Irish American women -- History -- 19th century."
+                            ]
+                        }
+                    }
+                ]
+            }
+        ],
+        "otherfindaid": [
+            {
+                "id": "aspace_0b719130b0efb4b3dd232a74de098aa9",
+                "head": {
+                    "value": "Other Finding Aids"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the Other Finding Aids note."
+                        }
+                    }
+                ]
+            }
+        ],
+        "originalsloc": [
+            {
+                "id": "aspace_aa0a0cdc1b60f061cdbae4abf56bcfb7",
+                "head": {
+                    "value": "Existence and Location of Originals"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the Existence and Location of Originals note."
+                        }
+                    }
+                ]
+            }
+        ],
+        "phystech": [
+            {
+                "id": "aspace_6535a00a00c94c0593f378d76d4dec87",
+                "head": {
+                    "value": "Physical Characteristics and Technical Requirements"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the Physical Characteristics and Technical Requirements note."
+                        }
+                    }
+                ]
+            }
+        ],
+        "prefercite": [
+            {
+                "id": "aspace_3a758dcc0a9eafb7976839a96615fa21",
+                "head": {
+                    "value": "Preferred Citation"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the Preferred Citation note."
+                        }
+                    }
+                ]
+            }
+        ],
+        "processinfo": [
+            {
+                "id": "aspace_ede025697b8e5bd48a2e9752bb4eb634",
+                "head": {
+                    "value": "Processing Information"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the Processing Information note."
+                        }
+                    }
+                ]
+            }
+        ],
+        "relatedmaterial": [
+            {
+                "id": "aspace_5234804138e0f9a3a4639042d816b7f4",
+                "head": {
+                    "value": "Related Materials"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the Related Materials note. Those using the collection may also be interested in P132, held in this repository, which includes photographs of Pemberly, Darcy's estate and childhood home. In an April 1795 letter to his friend, Charles Bingley, Darcy wrote \u003cspan class=\"ead-blockquote\"\u003e \u003cspan class=\"ead-p\"\u003eNo doubt the estate has exerted a tremendous influence on the development of my character. One may walk for an hour without glimpsing another soul, which has taught me to love tranquility.\u003c/span\u003e \u003c/span\u003e \u003cspan class=\"ead-archref\"\u003e \u003ca class=\"ead-extref\" href=\"http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/\" target=\"\"\u003eThe Sally Belfrage Papers (TAM 189)\u003c/a\u003e\u003c/span\u003e",
+                            "archref": [
+                                {
+                                    "value": "\u003ca class=\"ead-extref\" href=\"http://dlib.nyu.edu/findingaids/html/tamwag/tam_189/\" target=\"\"\u003eThe Sally Belfrage Papers (TAM 189)\u003c/a\u003e"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ],
+        "scopecontent": [
+            {
+                "id": "aspace_c2e115638fa0f6448f8a05f567287451",
+                "head": {
+                    "value": "Scope and Content"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the Scope and Content note."
+                        }
+                    }
+                ]
+            }
+        ],
+        "separatedmaterial": [
+            {
+                "id": "aspace_93d92d0c1e70183fc245965ea55d1a8b",
+                "head": {
+                    "value": "Separated Materials"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the Separated Materials note."
+                        }
+                    }
+                ]
+            }
+        ],
+        "userestrict": [
+            {
+                "id": "aspace_2d8e669a800c026aefc9d7e76ca578c9",
+                "head": {
+                    "value": "Conditions Governing Use"
+                },
+                "children": [
+                    {
+                        "name": "p",
+                        "value": {
+                            "value": "This is the Conditions Governing Use note."
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "eadheader": {
+        "eadid": {
+            "url": "http://dlib.nyu.edu/findingaids/html/tamwag/mos_2021",
+            "value": "mos_2021"
+        },
+        "filedesc": {
+            "editionstmt": {
+                "p": [
+                    {
+                        "value": "First edition"
+                    }
+                ]
+            },
+            "notestmt": {
+                "note": [
+                    {
+                        "p": [
+                            {
+                                "value": "Here is a note."
+                            }
+                        ]
+                    }
+                ]
+            },
+            "publicationstmt": {
+                "address": [
+                    {
+                        "addressline": [
+                            {
+                                "value": "Elmer Holmes Bobst Library"
+                            },
+                            {
+                                "value": "70 Washington Square South"
+                            },
+                            {
+                                "value": "2nd Floor"
+                            },
+                            {
+                                "value": "New York, NY 10012"
+                            },
+                            {
+                                "value": "special.collections@nyu.edu"
+                            },
+                            {
+                                "value": "URL: \u003cspan class=\"ead-extptr\"\u003e\u003c/span\u003e",
+                                "extptr": [
+                                    {
+                                        "href": "http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/",
+                                        "show": "new",
+                                        "title": "http://library.nyu.edu/about/collections/special-collections-and-archives/special-collections/",
+                                        "type": "simple"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "p": [
+                    {
+                        "value": "\u003cspan class=\"ead-date\"\u003eMarch 2023\u003c/span\u003e",
+                        "date": [
+                            {
+                                "value": "March 2023"
+                            }
+                        ]
+                    }
+                ],
+                "publisher": "Tamiment Library and Robert F. Wagner Labor Archives"
+            },
+            "titlestmt": {
+                "author": "Megan O'Shea",
+                "sponsor": "Creation of this finding aid funded by New York University Libraries.",
+                "subtitle": "A Wicked Awesome Resource Record",
+                "titleproper": "Guide to Megan O'Shea's \u003cspan class=\"ead-emph ead-emph-italic\"\u003eOne\u003c/span\u003e Resource to \u003cspan class=\"ead-lb\"\u003e\u003c/span\u003e Rule Them All \u003cspan class=\"ead-num\"\u003eMOS.2021\u003c/span\u003e"
+            }
+        },
+        "profiledesc": {
+            "creation": {
+                "value": "This finding aid was produced using ArchivesSpace and manual edits on \u003cspan class=\"ead-date\"\u003e2023-03-23 13:50:52 -0400\u003c/span\u003e.",
+                "date": [
+                    {
+                        "value": "2023-03-23 13:50:52 -0400"
+                    }
+                ]
+            },
+            "descrules": "Describing Archives: A Content Standard",
+            "langusage": {
+                "value": "Finding aid written in \u003cspan class=\"ead-language\"\u003eEnglish\u003c/span\u003e.",
+                "language": [
+                    "English"
+                ]
+            }
+        },
+        "revisiondesc": {
+            "change": [
+                {
+                    "date": [
+                        {
+                            "value": "March 2021"
+                        }
+                    ],
+                    "item": [
+                        {
+                            "value": "Updated by Megan O'Shea in order to include this note"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/ead/testdata/tamwag/tam_143.json
+++ b/ead/testdata/tamwag/tam_143.json
@@ -843,12 +843,14 @@
                 {
                     "value": "1922-2003",
                     "type": "inclusive",
-                    "datechar": "creation"
+                    "datechar": "creation",
+                    "normal": "1922/2003"
                 },
                 {
                     "value": "1945-1985",
                     "type": "bulk",
-                    "datechar": "creation"
+                    "datechar": "creation",
+                    "normal": "1945/1985"
                 }
             ],
             "unitid": "TAM.143",
@@ -885,7 +887,8 @@
                                     {
                                         "value": "undated",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1922/1990"
                                     }
                                 ],
                                 "unittitle": {
@@ -916,7 +919,8 @@
                                     {
                                         "value": "1922-1936",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1922/1936"
                                     }
                                 ],
                                 "unittitle": {
@@ -947,7 +951,8 @@
                                     {
                                         "value": "1957 , 1959",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1957/1959"
                                     }
                                 ],
                                 "unittitle": {
@@ -978,7 +983,8 @@
                                     {
                                         "value": "1990",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1990/1990"
                                     }
                                 ],
                                 "unittitle": {
@@ -1009,7 +1015,8 @@
                                     {
                                         "value": "1962",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1962/1962"
                                     }
                                 ],
                                 "unittitle": {
@@ -1023,7 +1030,8 @@
                             {
                                 "value": "1922-1990",
                                 "type": "inclusive",
-                                "datechar": "creation"
+                                "datechar": "creation",
+                                "normal": "1922/1990"
                             }
                         ],
                         "unittitle": {
@@ -1078,7 +1086,8 @@
                                             {
                                                 "value": "1959-1971",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1959/1971"
                                             }
                                         ],
                                         "unittitle": {
@@ -1109,7 +1118,8 @@
                                             {
                                                 "value": "1972-1979",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1972/1979"
                                             }
                                         ],
                                         "unittitle": {
@@ -1140,7 +1150,8 @@
                                             {
                                                 "value": "1980-1987",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1980/1987"
                                             }
                                         ],
                                         "unittitle": {
@@ -1171,7 +1182,8 @@
                                             {
                                                 "value": "1955-1963",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1955/1963"
                                             }
                                         ],
                                         "unittitle": {
@@ -1202,7 +1214,8 @@
                                             {
                                                 "value": "1964-1979",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1964/1979"
                                             }
                                         ],
                                         "unittitle": {
@@ -1233,7 +1246,8 @@
                                             {
                                                 "value": "1980-1987",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1980/1987"
                                             }
                                         ],
                                         "unittitle": {
@@ -1264,7 +1278,8 @@
                                             {
                                                 "value": "1955-1986",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1955/1986"
                                             }
                                         ],
                                         "unittitle": {
@@ -1295,7 +1310,8 @@
                                             {
                                                 "value": "1961",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1961/1961"
                                             }
                                         ],
                                         "unittitle": {
@@ -1326,7 +1342,8 @@
                                             {
                                                 "value": "undated , 1953-1986",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -1340,7 +1357,8 @@
                                     {
                                         "value": "1953-1987",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1953/1987"
                                     }
                                 ],
                                 "unittitle": {
@@ -1375,7 +1393,8 @@
                                             {
                                                 "value": "1959-1969",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1959/1969"
                                             }
                                         ],
                                         "unittitle": {
@@ -1406,7 +1425,8 @@
                                             {
                                                 "value": "1970-1979",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1970/1979"
                                             }
                                         ],
                                         "unittitle": {
@@ -1437,7 +1457,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -1468,7 +1489,8 @@
                                             {
                                                 "value": "1955-1959",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1955/1959"
                                             }
                                         ],
                                         "unittitle": {
@@ -1499,7 +1521,8 @@
                                             {
                                                 "value": "1963-1969",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1963/1969"
                                             }
                                         ],
                                         "unittitle": {
@@ -1530,7 +1553,8 @@
                                             {
                                                 "value": "1970-1979",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1970/1979"
                                             }
                                         ],
                                         "unittitle": {
@@ -1561,7 +1585,8 @@
                                             {
                                                 "value": "1980-1990",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1980/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -1592,7 +1617,8 @@
                                             {
                                                 "value": "1963-1979",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1963/1979"
                                             }
                                         ],
                                         "unittitle": {
@@ -1623,7 +1649,8 @@
                                             {
                                                 "value": "1945 , 1970-1983",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1945/1983"
                                             }
                                         ],
                                         "unittitle": {
@@ -1654,7 +1681,8 @@
                                             {
                                                 "value": "1973",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1973/1973"
                                             }
                                         ],
                                         "unittitle": {
@@ -1685,7 +1713,8 @@
                                             {
                                                 "value": "1965-1976",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1965/1976"
                                             }
                                         ],
                                         "unittitle": {
@@ -1716,7 +1745,8 @@
                                             {
                                                 "value": "1945-1985",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1945/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -1747,7 +1777,8 @@
                                             {
                                                 "value": "1970-1986",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1970/1986"
                                             }
                                         ],
                                         "unittitle": {
@@ -1778,7 +1809,8 @@
                                             {
                                                 "value": "1983-1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1983/1984"
                                             }
                                         ],
                                         "unittitle": {
@@ -1809,7 +1841,8 @@
                                             {
                                                 "value": "1955-1964",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1955/1964"
                                             }
                                         ],
                                         "unittitle": {
@@ -1840,7 +1873,8 @@
                                             {
                                                 "value": "1963-1985",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1963/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -1871,7 +1905,8 @@
                                             {
                                                 "value": "1960",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1960/1960"
                                             }
                                         ],
                                         "unittitle": {
@@ -1902,7 +1937,8 @@
                                             {
                                                 "value": "1972-1988",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1972/1988"
                                             }
                                         ],
                                         "unittitle": {
@@ -1933,7 +1969,8 @@
                                             {
                                                 "value": "1946-1969",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1946/1969"
                                             }
                                         ],
                                         "unittitle": {
@@ -1964,7 +2001,8 @@
                                             {
                                                 "value": "1970-1987",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1970/1987"
                                             }
                                         ],
                                         "unittitle": {
@@ -1995,7 +2033,8 @@
                                             {
                                                 "value": "1961-1975",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1961/1975"
                                             }
                                         ],
                                         "unittitle": {
@@ -2026,7 +2065,8 @@
                                             {
                                                 "value": "1962-1982",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1962/1982"
                                             }
                                         ],
                                         "unittitle": {
@@ -2057,7 +2097,8 @@
                                             {
                                                 "value": "1953-1987",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1953/1987"
                                             }
                                         ],
                                         "unittitle": {
@@ -2088,7 +2129,8 @@
                                             {
                                                 "value": "1956",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1956/1956"
                                             }
                                         ],
                                         "unittitle": {
@@ -2119,7 +2161,8 @@
                                             {
                                                 "value": "1979-1981",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1979/1981"
                                             }
                                         ],
                                         "unittitle": {
@@ -2150,7 +2193,8 @@
                                             {
                                                 "value": "1956-1965",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1956/1965"
                                             }
                                         ],
                                         "unittitle": {
@@ -2181,7 +2225,8 @@
                                             {
                                                 "value": "1979-1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1979/1984"
                                             }
                                         ],
                                         "unittitle": {
@@ -2212,7 +2257,8 @@
                                             {
                                                 "value": "1977-1981",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1977/1981"
                                             }
                                         ],
                                         "unittitle": {
@@ -2243,7 +2289,8 @@
                                             {
                                                 "value": "1956-1957",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1956/1957"
                                             }
                                         ],
                                         "unittitle": {
@@ -2274,7 +2321,8 @@
                                             {
                                                 "value": "1979-1985",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1979/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -2305,7 +2353,8 @@
                                             {
                                                 "value": "1938-1967",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1938/1967"
                                             }
                                         ],
                                         "unittitle": {
@@ -2336,7 +2385,8 @@
                                             {
                                                 "value": "1968-1972",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1968/1972"
                                             }
                                         ],
                                         "unittitle": {
@@ -2367,7 +2417,8 @@
                                             {
                                                 "value": "1973-1980",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1973/1980"
                                             }
                                         ],
                                         "unittitle": {
@@ -2398,7 +2449,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -2429,7 +2481,8 @@
                                             {
                                                 "value": "1943-1980",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1943/1980"
                                             }
                                         ],
                                         "unittitle": {
@@ -2460,7 +2513,8 @@
                                             {
                                                 "value": "1982-1986",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1982/1986"
                                             }
                                         ],
                                         "unittitle": {
@@ -2474,7 +2528,8 @@
                                     {
                                         "value": "1938-1988",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1938/1988"
                                     }
                                 ],
                                 "unittitle": {
@@ -2509,7 +2564,8 @@
                                             {
                                                 "value": "1940-1979",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1940/1979"
                                             }
                                         ],
                                         "unittitle": {
@@ -2540,7 +2596,8 @@
                                             {
                                                 "value": "1937-1980",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1937/1980"
                                             }
                                         ],
                                         "unittitle": {
@@ -2571,7 +2628,8 @@
                                             {
                                                 "value": "1963-1972",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1963/1972"
                                             }
                                         ],
                                         "unittitle": {
@@ -2602,7 +2660,8 @@
                                             {
                                                 "value": "1961-1966",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1961/1966"
                                             }
                                         ],
                                         "unittitle": {
@@ -2633,7 +2692,8 @@
                                             {
                                                 "value": "1967-1986",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1967/1986"
                                             }
                                         ],
                                         "unittitle": {
@@ -2664,7 +2724,8 @@
                                             {
                                                 "value": "1961-1985",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1961/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -2695,7 +2756,8 @@
                                             {
                                                 "value": "1938-1987",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1938/1987"
                                             }
                                         ],
                                         "unittitle": {
@@ -2726,7 +2788,8 @@
                                             {
                                                 "value": "1939-1972",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1939/1972"
                                             }
                                         ],
                                         "unittitle": {
@@ -2757,7 +2820,8 @@
                                             {
                                                 "value": "1973-1986",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1973/1986"
                                             }
                                         ],
                                         "unittitle": {
@@ -2788,7 +2852,8 @@
                                             {
                                                 "value": "1963-1972",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1963/1972"
                                             }
                                         ],
                                         "unittitle": {
@@ -2819,7 +2884,8 @@
                                             {
                                                 "value": "1973-1987",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1973/1987"
                                             }
                                         ],
                                         "unittitle": {
@@ -2850,7 +2916,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -2881,7 +2948,8 @@
                                             {
                                                 "value": "1962-1985",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1962/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -2912,7 +2980,8 @@
                                             {
                                                 "value": "1942-1964",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1942/1964"
                                             }
                                         ],
                                         "unittitle": {
@@ -2943,7 +3012,8 @@
                                             {
                                                 "value": "1965-1967",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1965/1967"
                                             }
                                         ],
                                         "unittitle": {
@@ -2974,7 +3044,8 @@
                                             {
                                                 "value": "1968-1973",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1968/1973"
                                             }
                                         ],
                                         "unittitle": {
@@ -3005,7 +3076,8 @@
                                             {
                                                 "value": "1974-1978",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1978"
                                             }
                                         ],
                                         "unittitle": {
@@ -3036,7 +3108,8 @@
                                             {
                                                 "value": "1979-1982",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1979/1982"
                                             }
                                         ],
                                         "unittitle": {
@@ -3067,7 +3140,8 @@
                                             {
                                                 "value": "1983-1989",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1983/1989"
                                             }
                                         ],
                                         "unittitle": {
@@ -3098,7 +3172,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -3112,7 +3187,8 @@
                                     {
                                         "value": "1937-1989",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1937/1989"
                                     }
                                 ],
                                 "unittitle": {
@@ -3126,7 +3202,8 @@
                             {
                                 "value": "1937-1989",
                                 "type": "inclusive",
-                                "datechar": "creation"
+                                "datechar": "creation",
+                                "normal": "1937/1989"
                             }
                         ],
                         "unittitle": {
@@ -3259,7 +3336,8 @@
                                             {
                                                 "value": "1944-1945",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1944/1945"
                                             }
                                         ],
                                         "unittitle": {
@@ -3297,7 +3375,8 @@
                                             {
                                                 "value": "1945-1946",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1945/1946"
                                             }
                                         ],
                                         "unittitle": {
@@ -3311,7 +3390,8 @@
                                     {
                                         "value": "1944-1946",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1944/1946"
                                     }
                                 ],
                                 "unittitle": {
@@ -3346,7 +3426,8 @@
                                             {
                                                 "value": "ca.1949",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1939/1959"
                                             }
                                         ],
                                         "unittitle": {
@@ -3377,7 +3458,8 @@
                                             {
                                                 "value": "1949",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1949/1949"
                                             }
                                         ],
                                         "unittitle": {
@@ -3408,7 +3490,8 @@
                                             {
                                                 "value": "1952-1953",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1952/1953"
                                             }
                                         ],
                                         "unittitle": {
@@ -3445,7 +3528,8 @@
                                             {
                                                 "value": "1953",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1953/1953"
                                             }
                                         ],
                                         "unittitle": {
@@ -3476,7 +3560,8 @@
                                             {
                                                 "value": "1953",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1953/1953"
                                             }
                                         ],
                                         "unittitle": {
@@ -3507,7 +3592,8 @@
                                             {
                                                 "value": "ca.1953",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1943/1963"
                                             }
                                         ],
                                         "unittitle": {
@@ -3538,7 +3624,8 @@
                                             {
                                                 "value": "1953",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1953/1953"
                                             }
                                         ],
                                         "unittitle": {
@@ -3569,7 +3656,8 @@
                                             {
                                                 "value": "1953",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1953/1953"
                                             }
                                         ],
                                         "unittitle": {
@@ -3600,7 +3688,8 @@
                                             {
                                                 "value": "1953",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1953/1953"
                                             }
                                         ],
                                         "unittitle": {
@@ -3631,7 +3720,8 @@
                                             {
                                                 "value": "1953",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1953/1953"
                                             }
                                         ],
                                         "unittitle": {
@@ -3662,7 +3752,8 @@
                                             {
                                                 "value": "1953",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1953/1953"
                                             }
                                         ],
                                         "unittitle": {
@@ -3693,7 +3784,8 @@
                                             {
                                                 "value": "1953",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1953/1953"
                                             }
                                         ],
                                         "unittitle": {
@@ -3724,7 +3816,8 @@
                                             {
                                                 "value": "1953-1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1953/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -3755,7 +3848,8 @@
                                             {
                                                 "value": "1953-1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1953/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -3786,7 +3880,8 @@
                                             {
                                                 "value": "1953-1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1953/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -3817,7 +3912,8 @@
                                             {
                                                 "value": "1953-1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1953/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -3848,7 +3944,8 @@
                                             {
                                                 "value": "1953-1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1953/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -3879,7 +3976,8 @@
                                             {
                                                 "value": "1954-1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1954/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -3916,7 +4014,8 @@
                                             {
                                                 "value": "1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1955/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -3947,7 +4046,8 @@
                                             {
                                                 "value": "ca.1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1945/1965"
                                             }
                                         ],
                                         "unittitle": {
@@ -3978,7 +4078,8 @@
                                             {
                                                 "value": "1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1955/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -4009,7 +4110,8 @@
                                             {
                                                 "value": "1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1955/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -4040,7 +4142,8 @@
                                             {
                                                 "value": "1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1955/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -4071,7 +4174,8 @@
                                             {
                                                 "value": "ca.1980",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1970/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -4102,7 +4206,8 @@
                                             {
                                                 "value": "1984-1985",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1984/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -4133,7 +4238,8 @@
                                             {
                                                 "value": "1949-1953 , undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1949/1953"
                                             }
                                         ],
                                         "unittitle": {
@@ -4164,7 +4270,8 @@
                                             {
                                                 "value": "1953-1958",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1953/1958"
                                             }
                                         ],
                                         "unittitle": {
@@ -4178,7 +4285,8 @@
                                     {
                                         "value": "1944-1989",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1944/1989"
                                     }
                                 ],
                                 "unittitle": {
@@ -4213,7 +4321,8 @@
                                             {
                                                 "value": "1948",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1948/1948"
                                             }
                                         ],
                                         "unittitle": {
@@ -4250,7 +4359,8 @@
                                             {
                                                 "value": "ca.1948",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1938/1958"
                                             }
                                         ],
                                         "unittitle": {
@@ -4281,7 +4391,8 @@
                                             {
                                                 "value": "1948-1951",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1948/1951"
                                             }
                                         ],
                                         "unittitle": {
@@ -4318,7 +4429,8 @@
                                             {
                                                 "value": "1948-1951",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1948/1951"
                                             }
                                         ],
                                         "unittitle": {
@@ -4349,7 +4461,8 @@
                                             {
                                                 "value": "1949",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1949/1949"
                                             }
                                         ],
                                         "unittitle": {
@@ -4380,7 +4493,8 @@
                                             {
                                                 "value": "ca.1949",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1939/1959"
                                             }
                                         ],
                                         "unittitle": {
@@ -4417,7 +4531,8 @@
                                             {
                                                 "value": "1950",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1950/1950"
                                             }
                                         ],
                                         "unittitle": {
@@ -4448,7 +4563,8 @@
                                             {
                                                 "value": "1945-1959",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1945/1959"
                                             }
                                         ],
                                         "unittitle": {
@@ -4485,7 +4601,8 @@
                                             {
                                                 "value": "1948-1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1948/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -4522,7 +4639,8 @@
                                             {
                                                 "value": "1956",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1956/1956"
                                             }
                                         ],
                                         "unittitle": {
@@ -4553,7 +4671,8 @@
                                             {
                                                 "value": "1956 , 1960",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1956/1960"
                                             }
                                         ],
                                         "unittitle": {
@@ -4590,7 +4709,8 @@
                                             {
                                                 "value": "1954-1967",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1954/1967"
                                             }
                                         ],
                                         "unittitle": {
@@ -4627,7 +4747,8 @@
                                             {
                                                 "value": "1963-1966",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1963/1966"
                                             }
                                         ],
                                         "unittitle": {
@@ -4664,7 +4785,8 @@
                                             {
                                                 "value": "1968",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1968/1968"
                                             }
                                         ],
                                         "unittitle": {
@@ -4705,7 +4827,8 @@
                                             {
                                                 "value": "ca.1970",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1960/1980"
                                             }
                                         ],
                                         "unittitle": {
@@ -4741,7 +4864,8 @@
                                                     {
                                                         "value": "1967",
                                                         "type": "inclusive",
-                                                        "datechar": "creation"
+                                                        "datechar": "creation",
+                                                        "normal": "1967/1967"
                                                     }
                                                 ],
                                                 "unittitle": {
@@ -4775,7 +4899,8 @@
                                             {
                                                 "value": "1972",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1972/1972"
                                             }
                                         ],
                                         "unittitle": {
@@ -4812,7 +4937,8 @@
                                             {
                                                 "value": "ca.1974",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1964/1984"
                                             }
                                         ],
                                         "unittitle": {
@@ -4853,7 +4979,8 @@
                                             {
                                                 "value": "1948-1983",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1948/1983"
                                             }
                                         ],
                                         "unittitle": {
@@ -4884,7 +5011,8 @@
                                             {
                                                 "value": "ca.1984-1987",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1997"
                                             }
                                         ],
                                         "unittitle": {
@@ -4925,7 +5053,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -4962,7 +5091,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -4999,7 +5129,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -5019,7 +5150,8 @@
                                     {
                                         "value": "1948-1987",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1948/1987"
                                     }
                                 ],
                                 "unittitle": {
@@ -5039,7 +5171,8 @@
                             {
                                 "value": "1944-1989",
                                 "type": "inclusive",
-                                "datechar": "creation"
+                                "datechar": "creation",
+                                "normal": "1944/1989"
                             }
                         ],
                         "unittitle": {
@@ -5094,7 +5227,8 @@
                                             {
                                                 "value": "1956",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1956/1956"
                                             }
                                         ],
                                         "unittitle": {
@@ -5125,7 +5259,8 @@
                                             {
                                                 "value": "1957",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1957/1957"
                                             }
                                         ],
                                         "unittitle": {
@@ -5156,7 +5291,8 @@
                                             {
                                                 "value": "1957-1958",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1957/1958"
                                             }
                                         ],
                                         "unittitle": {
@@ -5187,7 +5323,8 @@
                                             {
                                                 "value": "1958",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1958/1958"
                                             }
                                         ],
                                         "unittitle": {
@@ -5218,7 +5355,8 @@
                                             {
                                                 "value": "1959",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1959/1959"
                                             }
                                         ],
                                         "unittitle": {
@@ -5249,7 +5387,8 @@
                                             {
                                                 "value": "1961",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1961/1961"
                                             }
                                         ],
                                         "unittitle": {
@@ -5280,7 +5419,8 @@
                                             {
                                                 "value": "1961-1962",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1961/1962"
                                             }
                                         ],
                                         "unittitle": {
@@ -5311,7 +5451,8 @@
                                             {
                                                 "value": "1963",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1963/1963"
                                             }
                                         ],
                                         "unittitle": {
@@ -5342,7 +5483,8 @@
                                             {
                                                 "value": "1964-1966",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1964/1966"
                                             }
                                         ],
                                         "unittitle": {
@@ -5373,7 +5515,8 @@
                                             {
                                                 "value": "1966",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1966/1966"
                                             }
                                         ],
                                         "unittitle": {
@@ -5404,7 +5547,8 @@
                                             {
                                                 "value": "1965-1971",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1965/1971"
                                             }
                                         ],
                                         "unittitle": {
@@ -5435,7 +5579,8 @@
                                             {
                                                 "value": "1971",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1971/1971"
                                             }
                                         ],
                                         "unittitle": {
@@ -5466,7 +5611,8 @@
                                             {
                                                 "value": "1975-1977",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1975/1977"
                                             }
                                         ],
                                         "unittitle": {
@@ -5480,7 +5626,8 @@
                                     {
                                         "value": "1956-1977",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1956/1977"
                                     }
                                 ],
                                 "unittitle": {
@@ -5515,7 +5662,8 @@
                                             {
                                                 "value": "1946-1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1946/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -5546,7 +5694,8 @@
                                             {
                                                 "value": "ca.1948-1960",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1938/1970"
                                             }
                                         ],
                                         "unittitle": {
@@ -5577,7 +5726,8 @@
                                             {
                                                 "value": "1956",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1956/1956"
                                             }
                                         ],
                                         "unittitle": {
@@ -5608,7 +5758,8 @@
                                             {
                                                 "value": "1956-1959",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1956/1959"
                                             }
                                         ],
                                         "unittitle": {
@@ -5639,7 +5790,8 @@
                                             {
                                                 "value": "ca.1957-1959",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1947/1969"
                                             }
                                         ],
                                         "unittitle": {
@@ -5670,7 +5822,8 @@
                                             {
                                                 "value": "1966",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1966/1966"
                                             }
                                         ],
                                         "unittitle": {
@@ -5701,7 +5854,8 @@
                                             {
                                                 "value": "1977-1978",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1977/1978"
                                             }
                                         ],
                                         "unittitle": {
@@ -5742,7 +5896,8 @@
                                             {
                                                 "value": "ca.1969-1979",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1959/1989"
                                             }
                                         ],
                                         "unittitle": {
@@ -5773,7 +5928,8 @@
                                             {
                                                 "value": "1985",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1985/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -5804,7 +5960,8 @@
                                             {
                                                 "value": "1986-1987",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1986/1987"
                                             }
                                         ],
                                         "unittitle": {
@@ -5824,7 +5981,8 @@
                                     {
                                         "value": "1946-1987",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1946/1987"
                                     }
                                 ],
                                 "unittitle": {
@@ -5859,7 +6017,8 @@
                                             {
                                                 "value": "1972-1988",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1972/1988"
                                             }
                                         ],
                                         "unittitle": {
@@ -5890,7 +6049,8 @@
                                             {
                                                 "value": "ca.1976",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1966/1986"
                                             }
                                         ],
                                         "unittitle": {
@@ -5921,7 +6081,8 @@
                                             {
                                                 "value": "1966-1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1966/1984"
                                             }
                                         ],
                                         "unittitle": {
@@ -5952,7 +6113,8 @@
                                             {
                                                 "value": "1985-1986",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1985/1986"
                                             }
                                         ],
                                         "unittitle": {
@@ -5983,7 +6145,8 @@
                                             {
                                                 "value": "1984-1989",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1984/1989"
                                             }
                                         ],
                                         "unittitle": {
@@ -5997,7 +6160,8 @@
                                     {
                                         "value": "1966-1989",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1966/1989"
                                     }
                                 ],
                                 "unittitle": {
@@ -6032,7 +6196,8 @@
                                             {
                                                 "value": "1940",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1940/1940"
                                             }
                                         ],
                                         "unittitle": {
@@ -6063,7 +6228,8 @@
                                             {
                                                 "value": "1937-1956",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1937/1956"
                                             }
                                         ],
                                         "unittitle": {
@@ -6094,7 +6260,8 @@
                                             {
                                                 "value": "1939-1971",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1939/1971"
                                             }
                                         ],
                                         "unittitle": {
@@ -6125,7 +6292,8 @@
                                             {
                                                 "value": "1940",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1940/1940"
                                             }
                                         ],
                                         "unittitle": {
@@ -6156,7 +6324,8 @@
                                             {
                                                 "value": "ca.1947",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1937/1957"
                                             }
                                         ],
                                         "unittitle": {
@@ -6187,7 +6356,8 @@
                                             {
                                                 "value": "ca.1948-1951",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1938/1961"
                                             }
                                         ],
                                         "unittitle": {
@@ -6218,7 +6388,8 @@
                                             {
                                                 "value": "1955-1965",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1955/1965"
                                             }
                                         ],
                                         "unittitle": {
@@ -6249,7 +6420,8 @@
                                             {
                                                 "value": "1957",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1957/1957"
                                             }
                                         ],
                                         "unittitle": {
@@ -6280,7 +6452,8 @@
                                             {
                                                 "value": "1957",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1957/1957"
                                             }
                                         ],
                                         "unittitle": {
@@ -6311,7 +6484,8 @@
                                             {
                                                 "value": "1957",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1957/1957"
                                             }
                                         ],
                                         "unittitle": {
@@ -6342,7 +6516,8 @@
                                             {
                                                 "value": "1955-1957",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1955/1957"
                                             }
                                         ],
                                         "unittitle": {
@@ -6373,7 +6548,8 @@
                                             {
                                                 "value": "1960",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1960/1960"
                                             }
                                         ],
                                         "unittitle": {
@@ -6404,7 +6580,8 @@
                                             {
                                                 "value": "1961",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1961/1961"
                                             }
                                         ],
                                         "unittitle": {
@@ -6435,7 +6612,8 @@
                                             {
                                                 "value": "1964",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1964/1964"
                                             }
                                         ],
                                         "unittitle": {
@@ -6466,7 +6644,8 @@
                                             {
                                                 "value": "1966-1967",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1966/1967"
                                             }
                                         ],
                                         "unittitle": {
@@ -6497,7 +6676,8 @@
                                             {
                                                 "value": "1971-1982",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1971/1982"
                                             }
                                         ],
                                         "unittitle": {
@@ -6528,7 +6708,8 @@
                                             {
                                                 "value": "1974",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1974"
                                             }
                                         ],
                                         "unittitle": {
@@ -6559,7 +6740,8 @@
                                             {
                                                 "value": "1974",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1974"
                                             }
                                         ],
                                         "unittitle": {
@@ -6590,7 +6772,8 @@
                                             {
                                                 "value": "ca.1977-1978",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1967/1988"
                                             }
                                         ],
                                         "unittitle": {
@@ -6621,7 +6804,8 @@
                                             {
                                                 "value": "1978",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1978/1978"
                                             }
                                         ],
                                         "unittitle": {
@@ -6652,7 +6836,8 @@
                                             {
                                                 "value": "ca.1978",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1968/1988"
                                             }
                                         ],
                                         "unittitle": {
@@ -6683,7 +6868,8 @@
                                             {
                                                 "value": "1979",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1979/1979"
                                             }
                                         ],
                                         "unittitle": {
@@ -6714,7 +6900,8 @@
                                             {
                                                 "value": "1975-1980",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1975/1980"
                                             }
                                         ],
                                         "unittitle": {
@@ -6745,7 +6932,8 @@
                                             {
                                                 "value": "1978-1980",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1978/1980"
                                             }
                                         ],
                                         "unittitle": {
@@ -6776,7 +6964,8 @@
                                             {
                                                 "value": "1979-1985",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1979/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -6807,7 +6996,8 @@
                                             {
                                                 "value": "1937-1949",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1937/1949"
                                             }
                                         ],
                                         "unittitle": {
@@ -6838,7 +7028,8 @@
                                             {
                                                 "value": "1950-1958",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1950/1958"
                                             }
                                         ],
                                         "unittitle": {
@@ -6869,7 +7060,8 @@
                                             {
                                                 "value": "1960-1969",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1960/1969"
                                             }
                                         ],
                                         "unittitle": {
@@ -6900,7 +7092,8 @@
                                             {
                                                 "value": "1970-1979",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1970/1979"
                                             }
                                         ],
                                         "unittitle": {
@@ -6931,7 +7124,8 @@
                                             {
                                                 "value": "1980-1990",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1980/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -6945,7 +7139,8 @@
                                     {
                                         "value": "1937-1990",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1937/1990"
                                     }
                                 ],
                                 "unittitle": {
@@ -6980,7 +7175,8 @@
                                             {
                                                 "value": "1941",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1941/1941"
                                             }
                                         ],
                                         "unittitle": {
@@ -7011,7 +7207,8 @@
                                             {
                                                 "value": "1946",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1946/1946"
                                             }
                                         ],
                                         "unittitle": {
@@ -7042,7 +7239,8 @@
                                             {
                                                 "value": "ca.1947",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1937/1957"
                                             }
                                         ],
                                         "unittitle": {
@@ -7073,7 +7271,8 @@
                                             {
                                                 "value": "ca.1947",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1937/1957"
                                             }
                                         ],
                                         "unittitle": {
@@ -7104,7 +7303,8 @@
                                             {
                                                 "value": "1949",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1949/1949"
                                             }
                                         ],
                                         "unittitle": {
@@ -7135,7 +7335,8 @@
                                             {
                                                 "value": "1949-1956",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1949/1956"
                                             }
                                         ],
                                         "unittitle": {
@@ -7166,7 +7367,8 @@
                                             {
                                                 "value": "1950",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1950/1950"
                                             }
                                         ],
                                         "unittitle": {
@@ -7197,7 +7399,8 @@
                                             {
                                                 "value": "ca.1951",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1941/1961"
                                             }
                                         ],
                                         "unittitle": {
@@ -7228,7 +7431,8 @@
                                             {
                                                 "value": "ca.1951",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1941/1961"
                                             }
                                         ],
                                         "unittitle": {
@@ -7259,7 +7463,8 @@
                                             {
                                                 "value": "ca.1952",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1942/1962"
                                             }
                                         ],
                                         "unittitle": {
@@ -7290,7 +7495,8 @@
                                             {
                                                 "value": "ca.1956",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1946/1966"
                                             }
                                         ],
                                         "unittitle": {
@@ -7321,7 +7527,8 @@
                                             {
                                                 "value": "ca.1959-1964",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1949/1974"
                                             }
                                         ],
                                         "unittitle": {
@@ -7352,7 +7559,8 @@
                                             {
                                                 "value": "ca.1969-1971",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1959/1981"
                                             }
                                         ],
                                         "unittitle": {
@@ -7383,7 +7591,8 @@
                                             {
                                                 "value": "1974",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1974"
                                             }
                                         ],
                                         "unittitle": {
@@ -7414,7 +7623,8 @@
                                             {
                                                 "value": "ca.1975",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1965/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -7445,7 +7655,8 @@
                                             {
                                                 "value": "ca.1980",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1970/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -7476,7 +7687,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -7507,7 +7719,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -7538,7 +7751,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -7569,7 +7783,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -7600,7 +7815,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -7631,7 +7847,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -7662,7 +7879,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -7693,7 +7911,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -7724,7 +7943,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -7755,7 +7975,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -7769,7 +7990,8 @@
                                     {
                                         "value": "1941-1980",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1941/1980"
                                     }
                                 ],
                                 "unittitle": {
@@ -7804,7 +8026,8 @@
                                             {
                                                 "value": "ca.1970",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1960/1980"
                                             }
                                         ],
                                         "unittitle": {
@@ -7835,7 +8058,8 @@
                                             {
                                                 "value": "ca.1973",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1963/1983"
                                             }
                                         ],
                                         "unittitle": {
@@ -7866,7 +8090,8 @@
                                             {
                                                 "value": "1976-1979",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1976/1979"
                                             }
                                         ],
                                         "unittitle": {
@@ -7897,7 +8122,8 @@
                                             {
                                                 "value": "1969-1971",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1969/1971"
                                             }
                                         ],
                                         "unittitle": {
@@ -7928,7 +8154,8 @@
                                             {
                                                 "value": "1967-1970",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1967/1970"
                                             }
                                         ],
                                         "unittitle": {
@@ -7959,7 +8186,8 @@
                                             {
                                                 "value": "1971-1973",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1971/1973"
                                             }
                                         ],
                                         "unittitle": {
@@ -7990,7 +8218,8 @@
                                             {
                                                 "value": "1967-1969",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1967/1969"
                                             }
                                         ],
                                         "unittitle": {
@@ -8021,7 +8250,8 @@
                                             {
                                                 "value": "1968",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1968/1968"
                                             }
                                         ],
                                         "unittitle": {
@@ -8052,7 +8282,8 @@
                                             {
                                                 "value": "ca.1970",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1960/1980"
                                             }
                                         ],
                                         "unittitle": {
@@ -8083,7 +8314,8 @@
                                             {
                                                 "value": "ca.1973",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1963/1983"
                                             }
                                         ],
                                         "unittitle": {
@@ -8114,7 +8346,8 @@
                                             {
                                                 "value": "ca.1970",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1960/1980"
                                             }
                                         ],
                                         "unittitle": {
@@ -8145,7 +8378,8 @@
                                             {
                                                 "value": "ca.1989",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1979/1999"
                                             }
                                         ],
                                         "unittitle": {
@@ -8176,7 +8410,8 @@
                                             {
                                                 "value": "ca.1945-1960",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1935/1970"
                                             }
                                         ],
                                         "unittitle": {
@@ -8207,7 +8442,8 @@
                                             {
                                                 "value": "ca.1945-1950",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1935/1960"
                                             }
                                         ],
                                         "unittitle": {
@@ -8238,7 +8474,8 @@
                                             {
                                                 "value": "ca.1945-1950",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1935/1960"
                                             }
                                         ],
                                         "unittitle": {
@@ -8269,7 +8506,8 @@
                                             {
                                                 "value": "ca.1945-1950",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1935/1960"
                                             }
                                         ],
                                         "unittitle": {
@@ -8300,7 +8538,8 @@
                                             {
                                                 "value": "ca.1945-1950",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1935/1960"
                                             }
                                         ],
                                         "unittitle": {
@@ -8331,7 +8570,8 @@
                                             {
                                                 "value": "ca.1950",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1940/1960"
                                             }
                                         ],
                                         "unittitle": {
@@ -8362,7 +8602,8 @@
                                             {
                                                 "value": "ca.1951-1953",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1941/1963"
                                             }
                                         ],
                                         "unittitle": {
@@ -8393,7 +8634,8 @@
                                             {
                                                 "value": "ca.1950-1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1940/1965"
                                             }
                                         ],
                                         "unittitle": {
@@ -8424,7 +8666,8 @@
                                             {
                                                 "value": "ca.1954",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1944/1964"
                                             }
                                         ],
                                         "unittitle": {
@@ -8455,7 +8698,8 @@
                                             {
                                                 "value": "ca.1959",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1949/1969"
                                             }
                                         ],
                                         "unittitle": {
@@ -8486,7 +8730,8 @@
                                             {
                                                 "value": "ca.1960-1966",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1950/1976"
                                             }
                                         ],
                                         "unittitle": {
@@ -8517,7 +8762,8 @@
                                             {
                                                 "value": "ca.1966-1968",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1956/1978"
                                             }
                                         ],
                                         "unittitle": {
@@ -8548,7 +8794,8 @@
                                             {
                                                 "value": "1952-1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1952/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -8579,7 +8826,8 @@
                                             {
                                                 "value": "ca.1968",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1958/1978"
                                             }
                                         ],
                                         "unittitle": {
@@ -8610,7 +8858,8 @@
                                             {
                                                 "value": "1967",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1967/1967"
                                             }
                                         ],
                                         "unittitle": {
@@ -8641,7 +8890,8 @@
                                             {
                                                 "value": "ca.1973-1976",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1963/1986"
                                             }
                                         ],
                                         "unittitle": {
@@ -8672,7 +8922,8 @@
                                             {
                                                 "value": "ca.1970",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1960/1980"
                                             }
                                         ],
                                         "unittitle": {
@@ -8703,7 +8954,8 @@
                                             {
                                                 "value": "1989",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1989/1989"
                                             }
                                         ],
                                         "unittitle": {
@@ -8734,7 +8986,8 @@
                                             {
                                                 "value": "1984-1985",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1984/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -8748,7 +9001,8 @@
                                     {
                                         "value": "1945-1989",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1945/1989"
                                     }
                                 ],
                                 "unittitle": {
@@ -8783,7 +9037,8 @@
                                             {
                                                 "value": "ca.1955-1957",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1945/1967"
                                             }
                                         ],
                                         "unittitle": {
@@ -8814,7 +9069,8 @@
                                             {
                                                 "value": "ca.1953",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1943/1963"
                                             }
                                         ],
                                         "unittitle": {
@@ -8845,7 +9101,8 @@
                                             {
                                                 "value": "ca.1949-1946",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1939/1956"
                                             }
                                         ],
                                         "unittitle": {
@@ -8876,7 +9133,8 @@
                                             {
                                                 "value": "ca.1949",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1939/1959"
                                             }
                                         ],
                                         "unittitle": {
@@ -8907,7 +9165,8 @@
                                             {
                                                 "value": "ca.1954-1956",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1944/1966"
                                             }
                                         ],
                                         "unittitle": {
@@ -8938,7 +9197,8 @@
                                             {
                                                 "value": "ca.1952-1957",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1942/1967"
                                             }
                                         ],
                                         "unittitle": {
@@ -8969,7 +9229,8 @@
                                             {
                                                 "value": "ca.1950-1957",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1940/1967"
                                             }
                                         ],
                                         "unittitle": {
@@ -9000,7 +9261,8 @@
                                             {
                                                 "value": "ca.1950-1954",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1940/1964"
                                             }
                                         ],
                                         "unittitle": {
@@ -9031,7 +9293,8 @@
                                             {
                                                 "value": "ca.1952-1961",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1942/1971"
                                             }
                                         ],
                                         "unittitle": {
@@ -9062,7 +9325,8 @@
                                             {
                                                 "value": "1954",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1954/1954"
                                             }
                                         ],
                                         "unittitle": {
@@ -9093,7 +9357,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -9124,7 +9389,8 @@
                                             {
                                                 "value": "ca.1952",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1942/1962"
                                             }
                                         ],
                                         "unittitle": {
@@ -9155,7 +9421,8 @@
                                             {
                                                 "value": "ca.1956-1957",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1946/1967"
                                             }
                                         ],
                                         "unittitle": {
@@ -9186,7 +9453,8 @@
                                             {
                                                 "value": "1949-1952",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1949/1952"
                                             }
                                         ],
                                         "unittitle": {
@@ -9217,7 +9485,8 @@
                                             {
                                                 "value": "ca.1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1945/1965"
                                             }
                                         ],
                                         "unittitle": {
@@ -9248,7 +9517,8 @@
                                             {
                                                 "value": "ca.1957-1956",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1947/1966"
                                             }
                                         ],
                                         "unittitle": {
@@ -9279,7 +9549,8 @@
                                             {
                                                 "value": "ca.1950-1963",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1940/1973"
                                             }
                                         ],
                                         "unittitle": {
@@ -9310,7 +9581,8 @@
                                             {
                                                 "value": "ca.1957-1959",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1947/1969"
                                             }
                                         ],
                                         "unittitle": {
@@ -9341,7 +9613,8 @@
                                             {
                                                 "value": "ca.1954-1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1944/1965"
                                             }
                                         ],
                                         "unittitle": {
@@ -9372,7 +9645,8 @@
                                             {
                                                 "value": "ca.1952-1963",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1942/1973"
                                             }
                                         ],
                                         "unittitle": {
@@ -9403,7 +9677,8 @@
                                             {
                                                 "value": "ca.1954-1958",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1944/1968"
                                             }
                                         ],
                                         "unittitle": {
@@ -9434,7 +9709,8 @@
                                             {
                                                 "value": "ca.1956",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1946/1966"
                                             }
                                         ],
                                         "unittitle": {
@@ -9465,7 +9741,8 @@
                                             {
                                                 "value": "1949",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1949/1949"
                                             }
                                         ],
                                         "unittitle": {
@@ -9496,7 +9773,8 @@
                                             {
                                                 "value": "ca.1953-1957",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1943/1967"
                                             }
                                         ],
                                         "unittitle": {
@@ -9527,7 +9805,8 @@
                                             {
                                                 "value": "1959",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1959/1959"
                                             }
                                         ],
                                         "unittitle": {
@@ -9558,7 +9837,8 @@
                                             {
                                                 "value": "ca.1970",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1960/1980"
                                             }
                                         ],
                                         "unittitle": {
@@ -9589,7 +9869,8 @@
                                             {
                                                 "value": "ca.1955-1960",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1945/1970"
                                             }
                                         ],
                                         "unittitle": {
@@ -9620,7 +9901,8 @@
                                             {
                                                 "value": "ca.1965-1967",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1955/1977"
                                             }
                                         ],
                                         "unittitle": {
@@ -9651,7 +9933,8 @@
                                             {
                                                 "value": "1958",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1958/1958"
                                             }
                                         ],
                                         "unittitle": {
@@ -9682,7 +9965,8 @@
                                             {
                                                 "value": "ca.1950",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1940/1960"
                                             }
                                         ],
                                         "unittitle": {
@@ -9713,7 +9997,8 @@
                                             {
                                                 "value": "ca.1945-1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1935/1965"
                                             }
                                         ],
                                         "unittitle": {
@@ -9744,7 +10029,8 @@
                                             {
                                                 "value": "ca.1970",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1960/1980"
                                             }
                                         ],
                                         "unittitle": {
@@ -9775,7 +10061,8 @@
                                             {
                                                 "value": "1970",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1970/1970"
                                             }
                                         ],
                                         "unittitle": {
@@ -9806,7 +10093,8 @@
                                             {
                                                 "value": "ca.1954-1958",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1944/1968"
                                             }
                                         ],
                                         "unittitle": {
@@ -9837,7 +10125,8 @@
                                             {
                                                 "value": "ca.1953-1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1943/1965"
                                             }
                                         ],
                                         "unittitle": {
@@ -9868,7 +10157,8 @@
                                             {
                                                 "value": "undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1922/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -9899,7 +10189,8 @@
                                             {
                                                 "value": "ca.1969-1971",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1959/1981"
                                             }
                                         ],
                                         "unittitle": {
@@ -9930,7 +10221,8 @@
                                             {
                                                 "value": "ca.1965-1969",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1955/1979"
                                             }
                                         ],
                                         "unittitle": {
@@ -9961,7 +10253,8 @@
                                             {
                                                 "value": "1971-1976",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1971/1976"
                                             }
                                         ],
                                         "unittitle": {
@@ -9992,7 +10285,8 @@
                                             {
                                                 "value": "ca.1968",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1958/1978"
                                             }
                                         ],
                                         "unittitle": {
@@ -10023,7 +10317,8 @@
                                             {
                                                 "value": "1968",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1968/1968"
                                             }
                                         ],
                                         "unittitle": {
@@ -10054,7 +10349,8 @@
                                             {
                                                 "value": "1968",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1968/1968"
                                             }
                                         ],
                                         "unittitle": {
@@ -10085,7 +10381,8 @@
                                             {
                                                 "value": "1972-1973",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1972/1973"
                                             }
                                         ],
                                         "unittitle": {
@@ -10116,7 +10413,8 @@
                                             {
                                                 "value": "1972-1973",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1972/1973"
                                             }
                                         ],
                                         "unittitle": {
@@ -10147,7 +10445,8 @@
                                             {
                                                 "value": "1972-1974",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1972/1974"
                                             }
                                         ],
                                         "unittitle": {
@@ -10178,7 +10477,8 @@
                                             {
                                                 "value": "1973",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1973/1973"
                                             }
                                         ],
                                         "unittitle": {
@@ -10209,7 +10509,8 @@
                                             {
                                                 "value": "1973-1975",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1973/1975"
                                             }
                                         ],
                                         "unittitle": {
@@ -10240,7 +10541,8 @@
                                             {
                                                 "value": "1973",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1973/1973"
                                             }
                                         ],
                                         "unittitle": {
@@ -10271,7 +10573,8 @@
                                             {
                                                 "value": "1973",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1973/1973"
                                             }
                                         ],
                                         "unittitle": {
@@ -10302,7 +10605,8 @@
                                             {
                                                 "value": "ca.1976",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1966/1986"
                                             }
                                         ],
                                         "unittitle": {
@@ -10333,7 +10637,8 @@
                                             {
                                                 "value": "1973-1977",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1973/1977"
                                             }
                                         ],
                                         "unittitle": {
@@ -10364,7 +10669,8 @@
                                             {
                                                 "value": "1977",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1977/1977"
                                             }
                                         ],
                                         "unittitle": {
@@ -10395,7 +10701,8 @@
                                             {
                                                 "value": "1971-1978",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1971/1978"
                                             }
                                         ],
                                         "unittitle": {
@@ -10409,7 +10716,8 @@
                                     {
                                         "value": "1945-1978",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1945/1978"
                                     }
                                 ],
                                 "unittitle": {
@@ -10444,7 +10752,8 @@
                                             {
                                                 "value": "1948 , 1956",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1948/1956"
                                             }
                                         ],
                                         "unittitle": {
@@ -10475,7 +10784,8 @@
                                             {
                                                 "value": "1954",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1954/1954"
                                             }
                                         ],
                                         "unittitle": {
@@ -10506,7 +10816,8 @@
                                             {
                                                 "value": "1954",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1954/1954"
                                             }
                                         ],
                                         "unittitle": {
@@ -10537,7 +10848,8 @@
                                             {
                                                 "value": "1954",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1954/1954"
                                             }
                                         ],
                                         "unittitle": {
@@ -10568,7 +10880,8 @@
                                             {
                                                 "value": "1954-1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1954/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -10599,7 +10912,8 @@
                                             {
                                                 "value": "1954-1956",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1954/1956"
                                             }
                                         ],
                                         "unittitle": {
@@ -10630,7 +10944,8 @@
                                             {
                                                 "value": "1955-1956",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1955/1956"
                                             }
                                         ],
                                         "unittitle": {
@@ -10661,7 +10976,8 @@
                                             {
                                                 "value": "1956",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1956/1956"
                                             }
                                         ],
                                         "unittitle": {
@@ -10692,7 +11008,8 @@
                                             {
                                                 "value": "1956",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1956/1956"
                                             }
                                         ],
                                         "unittitle": {
@@ -10723,7 +11040,8 @@
                                             {
                                                 "value": "1956",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1956/1956"
                                             }
                                         ],
                                         "unittitle": {
@@ -10754,7 +11072,8 @@
                                             {
                                                 "value": "1956",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1956/1956"
                                             }
                                         ],
                                         "unittitle": {
@@ -10785,7 +11104,8 @@
                                             {
                                                 "value": "1957",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1957/1957"
                                             }
                                         ],
                                         "unittitle": {
@@ -10816,7 +11136,8 @@
                                             {
                                                 "value": "1957",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1957/1957"
                                             }
                                         ],
                                         "unittitle": {
@@ -10847,7 +11168,8 @@
                                             {
                                                 "value": "1956-1958",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1956/1958"
                                             }
                                         ],
                                         "unittitle": {
@@ -10878,7 +11200,8 @@
                                             {
                                                 "value": "1956-1959",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1956/1959"
                                             }
                                         ],
                                         "unittitle": {
@@ -10909,7 +11232,8 @@
                                             {
                                                 "value": "1947-1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1947/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -10940,7 +11264,8 @@
                                             {
                                                 "value": "1948",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1948/1948"
                                             }
                                         ],
                                         "unittitle": {
@@ -10971,7 +11296,8 @@
                                             {
                                                 "value": "1953-1954",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1953/1954"
                                             }
                                         ],
                                         "unittitle": {
@@ -11002,7 +11328,8 @@
                                             {
                                                 "value": "1954",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1954/1954"
                                             }
                                         ],
                                         "unittitle": {
@@ -11033,7 +11360,8 @@
                                             {
                                                 "value": "1954",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1954/1954"
                                             }
                                         ],
                                         "unittitle": {
@@ -11064,7 +11392,8 @@
                                             {
                                                 "value": "1954",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1954/1954"
                                             }
                                         ],
                                         "unittitle": {
@@ -11095,7 +11424,8 @@
                                             {
                                                 "value": "1954",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1954/1954"
                                             }
                                         ],
                                         "unittitle": {
@@ -11126,7 +11456,8 @@
                                             {
                                                 "value": "1954",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1954/1954"
                                             }
                                         ],
                                         "unittitle": {
@@ -11157,7 +11488,8 @@
                                             {
                                                 "value": "1954",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1954/1954"
                                             }
                                         ],
                                         "unittitle": {
@@ -11188,7 +11520,8 @@
                                             {
                                                 "value": "1961",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1961/1961"
                                             }
                                         ],
                                         "unittitle": {
@@ -11219,7 +11552,8 @@
                                             {
                                                 "value": "1946-1960",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1946/1960"
                                             }
                                         ],
                                         "unittitle": {
@@ -11233,7 +11567,8 @@
                                     {
                                         "value": "1946-1961",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1946/1961"
                                     }
                                 ],
                                 "unittitle": {
@@ -11268,7 +11603,8 @@
                                             {
                                                 "value": "ca.1974",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1964/1984"
                                             }
                                         ],
                                         "unittitle": {
@@ -11299,7 +11635,8 @@
                                             {
                                                 "value": "ca.1981",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1971/1991"
                                             }
                                         ],
                                         "unittitle": {
@@ -11330,7 +11667,8 @@
                                             {
                                                 "value": "ca.1981",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1971/1991"
                                             }
                                         ],
                                         "unittitle": {
@@ -11361,7 +11699,8 @@
                                             {
                                                 "value": "ca.1981",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1971/1991"
                                             }
                                         ],
                                         "unittitle": {
@@ -11392,7 +11731,8 @@
                                             {
                                                 "value": "ca.1981",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1971/1991"
                                             }
                                         ],
                                         "unittitle": {
@@ -11423,7 +11763,8 @@
                                             {
                                                 "value": "ca.1981",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1971/1991"
                                             }
                                         ],
                                         "unittitle": {
@@ -11454,7 +11795,8 @@
                                             {
                                                 "value": "ca.1981",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1971/1991"
                                             }
                                         ],
                                         "unittitle": {
@@ -11468,7 +11810,8 @@
                                     {
                                         "value": "1974-1981",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1974/1981"
                                     }
                                 ],
                                 "unittitle": {
@@ -11503,7 +11846,8 @@
                                             {
                                                 "value": "1931-1932",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1931/1932"
                                             }
                                         ],
                                         "unittitle": {
@@ -11534,7 +11878,8 @@
                                             {
                                                 "value": "1931",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1931/1931"
                                             }
                                         ],
                                         "unittitle": {
@@ -11571,7 +11916,8 @@
                                             {
                                                 "value": "1932",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1932/1932"
                                             }
                                         ],
                                         "unittitle": {
@@ -11608,7 +11954,8 @@
                                             {
                                                 "value": "1932",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1932/1932"
                                             }
                                         ],
                                         "unittitle": {
@@ -11645,7 +11992,8 @@
                                             {
                                                 "value": "1933-1934",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1933/1934"
                                             }
                                         ],
                                         "unittitle": {
@@ -11682,7 +12030,8 @@
                                             {
                                                 "value": "1934",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1934/1934"
                                             }
                                         ],
                                         "unittitle": {
@@ -11719,7 +12068,8 @@
                                             {
                                                 "value": "1935",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1935/1935"
                                             }
                                         ],
                                         "unittitle": {
@@ -11756,7 +12106,8 @@
                                             {
                                                 "value": "1927-1932",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1927/1932"
                                             }
                                         ],
                                         "unittitle": {
@@ -11787,7 +12138,8 @@
                                             {
                                                 "value": "ca.1973",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1963/1983"
                                             }
                                         ],
                                         "unittitle": {
@@ -11818,7 +12170,8 @@
                                             {
                                                 "value": "1928-1930",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1928/1930"
                                             }
                                         ],
                                         "unittitle": {
@@ -11855,7 +12208,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -11886,7 +12240,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -11917,7 +12272,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -11948,7 +12304,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -11979,7 +12336,8 @@
                                             {
                                                 "value": "1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1984/1984"
                                             }
                                         ],
                                         "unittitle": {
@@ -12010,7 +12368,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -12041,7 +12400,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -12072,7 +12432,8 @@
                                             {
                                                 "value": "1985-1986",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1985/1986"
                                             }
                                         ],
                                         "unittitle": {
@@ -12103,7 +12464,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -12134,7 +12496,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -12165,7 +12528,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -12196,7 +12560,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -12227,7 +12592,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -12258,7 +12624,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -12289,7 +12656,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -12320,7 +12688,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -12351,7 +12720,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -12382,7 +12752,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -12413,7 +12784,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -12444,7 +12816,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -12475,7 +12848,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -12506,7 +12880,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -12537,7 +12912,8 @@
                                             {
                                                 "value": "1924-1929",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1924/1929"
                                             }
                                         ],
                                         "unittitle": {
@@ -12568,7 +12944,8 @@
                                             {
                                                 "value": "1930-1932 , undated",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1930/1932"
                                             }
                                         ],
                                         "unittitle": {
@@ -12599,7 +12976,8 @@
                                             {
                                                 "value": "1927-1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1927/1984"
                                             }
                                         ],
                                         "unittitle": {
@@ -12630,7 +13008,8 @@
                                             {
                                                 "value": "ca.1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1974/1994"
                                             }
                                         ],
                                         "unittitle": {
@@ -12644,7 +13023,8 @@
                                     {
                                         "value": "1927-1984",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1927/1984"
                                     }
                                 ],
                                 "unittitle": {
@@ -12679,7 +13059,8 @@
                                             {
                                                 "value": "1947",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1947/1947"
                                             }
                                         ],
                                         "unittitle": {
@@ -12710,7 +13091,8 @@
                                             {
                                                 "value": "1948",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1948/1948"
                                             }
                                         ],
                                         "unittitle": {
@@ -12741,7 +13123,8 @@
                                             {
                                                 "value": "ca.1948",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1938/1958"
                                             }
                                         ],
                                         "unittitle": {
@@ -12772,7 +13155,8 @@
                                             {
                                                 "value": "ca.1948",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1938/1958"
                                             }
                                         ],
                                         "unittitle": {
@@ -12803,7 +13187,8 @@
                                             {
                                                 "value": "1942-1955",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1942/1955"
                                             }
                                         ],
                                         "unittitle": {
@@ -12834,7 +13219,8 @@
                                             {
                                                 "value": "1954",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1954/1954"
                                             }
                                         ],
                                         "unittitle": {
@@ -12865,7 +13251,8 @@
                                             {
                                                 "value": "1982-1984",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1982/1984"
                                             }
                                         ],
                                         "unittitle": {
@@ -12896,7 +13283,8 @@
                                             {
                                                 "value": "ca.1982",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1972/1992"
                                             }
                                         ],
                                         "unittitle": {
@@ -12927,7 +13315,8 @@
                                             {
                                                 "value": "1982",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1982/1982"
                                             }
                                         ],
                                         "unittitle": {
@@ -12958,7 +13347,8 @@
                                             {
                                                 "value": "1982",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1982/1982"
                                             }
                                         ],
                                         "unittitle": {
@@ -12989,7 +13379,8 @@
                                             {
                                                 "value": "1982",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1982/1982"
                                             }
                                         ],
                                         "unittitle": {
@@ -13020,7 +13411,8 @@
                                             {
                                                 "value": "1982",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1982/1982"
                                             }
                                         ],
                                         "unittitle": {
@@ -13051,7 +13443,8 @@
                                             {
                                                 "value": "1982",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1982/1982"
                                             }
                                         ],
                                         "unittitle": {
@@ -13082,7 +13475,8 @@
                                             {
                                                 "value": "1982",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1982/1982"
                                             }
                                         ],
                                         "unittitle": {
@@ -13113,7 +13507,8 @@
                                             {
                                                 "value": "1982",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1982/1982"
                                             }
                                         ],
                                         "unittitle": {
@@ -13144,7 +13539,8 @@
                                             {
                                                 "value": "1982",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1982/1982"
                                             }
                                         ],
                                         "unittitle": {
@@ -13175,7 +13571,8 @@
                                             {
                                                 "value": "1982",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1982/1982"
                                             }
                                         ],
                                         "unittitle": {
@@ -13206,7 +13603,8 @@
                                             {
                                                 "value": "1985",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1985/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -13237,7 +13635,8 @@
                                             {
                                                 "value": "ca.1985",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1975/1995"
                                             }
                                         ],
                                         "unittitle": {
@@ -13268,7 +13667,8 @@
                                             {
                                                 "value": "ca.1985",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1975/1995"
                                             }
                                         ],
                                         "unittitle": {
@@ -13299,7 +13699,8 @@
                                             {
                                                 "value": "ca.1985",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1975/1995"
                                             }
                                         ],
                                         "unittitle": {
@@ -13330,7 +13731,8 @@
                                             {
                                                 "value": "ca.1985",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1975/1995"
                                             }
                                         ],
                                         "unittitle": {
@@ -13361,7 +13763,8 @@
                                             {
                                                 "value": "1985",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1985/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -13375,7 +13778,8 @@
                                     {
                                         "value": "1947-1985",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1947/1985"
                                     }
                                 ],
                                 "unittitle": {
@@ -13410,7 +13814,8 @@
                                             {
                                                 "value": "1971-1973 ; 1990",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1971/1990"
                                             }
                                         ],
                                         "unittitle": {
@@ -13447,7 +13852,8 @@
                                             {
                                                 "value": "1969",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1969/1969"
                                             }
                                         ],
                                         "unittitle": {
@@ -13484,7 +13890,8 @@
                                             {
                                                 "value": "ca.1969",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1945/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -13521,7 +13928,8 @@
                                             {
                                                 "value": "ca.1969",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1945/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -13558,7 +13966,8 @@
                                             {
                                                 "value": "ca.1972",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1945/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -13595,7 +14004,8 @@
                                             {
                                                 "value": "ca.1972",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1945/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -13632,7 +14042,8 @@
                                             {
                                                 "value": "ca.1960",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1945/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -13669,7 +14080,8 @@
                                             {
                                                 "value": "ca.1960",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1945/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -13706,7 +14118,8 @@
                                             {
                                                 "value": "ca.1960",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1945/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -13743,7 +14156,8 @@
                                             {
                                                 "value": "ca.1960",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1945/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -13780,7 +14194,8 @@
                                             {
                                                 "value": "ca.1959-1960",
                                                 "type": "inclusive",
-                                                "datechar": "creation"
+                                                "datechar": "creation",
+                                                "normal": "1945/1985"
                                             }
                                         ],
                                         "unittitle": {
@@ -13830,7 +14245,8 @@
                                     {
                                         "value": "1959-1990",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1959/1990"
                                     }
                                 ],
                                 "unittitle": {
@@ -13854,7 +14270,8 @@
                             {
                                 "value": "1927-1990",
                                 "type": "inclusive",
-                                "datechar": "creation"
+                                "datechar": "creation",
+                                "normal": "1927/1990"
                             }
                         ],
                         "unittitle": {
@@ -13947,7 +14364,8 @@
                                     {
                                         "value": "1990",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1990/1990"
                                     }
                                 ],
                                 "unittitle": {
@@ -13978,7 +14396,8 @@
                                     {
                                         "value": "1945; 1973",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1945/1973"
                                     }
                                 ],
                                 "unittitle": {
@@ -14009,7 +14428,8 @@
                                     {
                                         "value": "1955",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1955/1955"
                                     }
                                 ],
                                 "unittitle": {
@@ -14040,7 +14460,8 @@
                                     {
                                         "value": "1996",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1996/1996"
                                     }
                                 ],
                                 "unittitle": {
@@ -14101,7 +14522,8 @@
                                     {
                                         "value": "1959-1960",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1959/1960"
                                     }
                                 ],
                                 "unittitle": {
@@ -14132,7 +14554,8 @@
                                     {
                                         "value": "1960",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1960/1960"
                                     }
                                 ],
                                 "unittitle": {
@@ -14163,7 +14586,8 @@
                                     {
                                         "value": "1990",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1990/1990"
                                     }
                                 ],
                                 "unittitle": {
@@ -14194,7 +14618,8 @@
                                     {
                                         "value": "1990",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1990/1990"
                                     }
                                 ],
                                 "unittitle": {
@@ -14225,7 +14650,8 @@
                                     {
                                         "value": "1950s-1990s",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1950/1990"
                                     }
                                 ],
                                 "unittitle": {
@@ -14256,7 +14682,8 @@
                                     {
                                         "value": "October, 1939",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1939/1939"
                                     }
                                 ],
                                 "unittitle": {
@@ -14347,7 +14774,8 @@
                                     {
                                         "value": "1955",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1955/1955"
                                     }
                                 ],
                                 "unittitle": {
@@ -14378,7 +14806,8 @@
                                     {
                                         "value": "Novemeber, 1939",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1939/1939"
                                     }
                                 ],
                                 "unittitle": {
@@ -14439,7 +14868,8 @@
                                     {
                                         "value": "1982",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1982/1982"
                                     }
                                 ],
                                 "unittitle": {
@@ -14950,7 +15380,8 @@
                                     {
                                         "value": "December 28, 1937",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1937/1937"
                                     }
                                 ],
                                 "unittitle": {
@@ -14981,7 +15412,8 @@
                                     {
                                         "value": "1923-1990",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1923/1990"
                                     }
                                 ],
                                 "unittitle": {
@@ -15012,7 +15444,8 @@
                                     {
                                         "value": "1980-1989",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1980/1989"
                                     }
                                 ],
                                 "unittitle": {
@@ -15043,7 +15476,8 @@
                                     {
                                         "value": "1990-1996",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1990/1996"
                                     }
                                 ],
                                 "unittitle": {
@@ -15104,7 +15538,8 @@
                                     {
                                         "value": "1990-1994",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1990/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -15165,7 +15600,8 @@
                                     {
                                         "value": "1960s",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1960/1969"
                                     }
                                 ],
                                 "unittitle": {
@@ -15196,7 +15632,8 @@
                                     {
                                         "value": "1959-1961",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1959/1961"
                                     }
                                 ],
                                 "unittitle": {
@@ -15227,7 +15664,8 @@
                                     {
                                         "value": "1958-1959",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1958/1959"
                                     }
                                 ],
                                 "unittitle": {
@@ -15258,7 +15696,8 @@
                                     {
                                         "value": "1990-1991",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1990/1991"
                                     }
                                 ],
                                 "unittitle": {
@@ -15319,7 +15758,8 @@
                                     {
                                         "value": "undated; 2001",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "2001/2001"
                                     }
                                 ],
                                 "unittitle": {
@@ -15350,7 +15790,8 @@
                                     {
                                         "value": "1920s-1930s",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1920/1939"
                                     }
                                 ],
                                 "unittitle": {
@@ -15411,7 +15852,8 @@
                                     {
                                         "value": "1966-1969",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1966/1969"
                                     }
                                 ],
                                 "unittitle": {
@@ -15442,7 +15884,8 @@
                                     {
                                         "value": "1991-1996",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1991/1996"
                                     }
                                 ],
                                 "unittitle": {
@@ -15593,7 +16036,8 @@
                                     {
                                         "value": "1960s",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1960/1969"
                                     }
                                 ],
                                 "unittitle": {
@@ -15624,7 +16068,8 @@
                                     {
                                         "value": "1995",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1995/1995"
                                     }
                                 ],
                                 "unittitle": {
@@ -15655,7 +16100,8 @@
                                     {
                                         "value": "1980-1994",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1980/1994"
                                     }
                                 ],
                                 "unittitle": {
@@ -15686,7 +16132,8 @@
                                     {
                                         "value": "1962",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1962/1962"
                                     }
                                 ],
                                 "unittitle": {
@@ -15717,7 +16164,8 @@
                                     {
                                         "value": "2002",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "2002/2002"
                                     }
                                 ],
                                 "unittitle": {
@@ -15748,7 +16196,8 @@
                                     {
                                         "value": "1989",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1989/1989"
                                     }
                                 ],
                                 "unittitle": {
@@ -15839,7 +16288,8 @@
                                     {
                                         "value": "Oct 1967-Sep 1968",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1967/1968"
                                     }
                                 ],
                                 "unittitle": {
@@ -15870,7 +16320,8 @@
                                     {
                                         "value": "Aug 1977",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1977/1977"
                                     }
                                 ],
                                 "unittitle": {
@@ -15901,7 +16352,8 @@
                                     {
                                         "value": "Jun/Jul 1973",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1973/1973"
                                     }
                                 ],
                                 "unittitle": {
@@ -15932,7 +16384,8 @@
                                     {
                                         "value": "Jul 10, 1945",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1945/1945"
                                     }
                                 ],
                                 "unittitle": {
@@ -15999,7 +16452,8 @@
                                     {
                                         "value": "undated",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1974/1976"
                                     }
                                 ],
                                 "unittitle": {
@@ -16013,7 +16467,8 @@
                             {
                                 "value": "1923-2003",
                                 "type": "inclusive",
-                                "datechar": "creation"
+                                "datechar": "creation",
+                                "normal": "1923/2003"
                             }
                         ],
                         "unittitle": {
@@ -16064,7 +16519,8 @@
                                     {
                                         "value": "1923-1973",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1923/1973"
                                     }
                                 ],
                                 "unittitle": {
@@ -16125,7 +16581,8 @@
                                     {
                                         "value": "1977",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1977/1977"
                                     }
                                 ],
                                 "unittitle": {
@@ -16156,7 +16613,8 @@
                                     {
                                         "value": "1930s",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1930/1939"
                                     }
                                 ],
                                 "unittitle": {
@@ -16187,7 +16645,8 @@
                                     {
                                         "value": "1940s",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1940/1949"
                                     }
                                 ],
                                 "unittitle": {
@@ -16218,7 +16677,8 @@
                                     {
                                         "value": "1950s",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1950/1959"
                                     }
                                 ],
                                 "unittitle": {
@@ -16249,7 +16709,8 @@
                                     {
                                         "value": "1960s",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1960/1969"
                                     }
                                 ],
                                 "unittitle": {
@@ -16280,7 +16741,8 @@
                                     {
                                         "value": "1970s-1990s",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1970/1999"
                                     }
                                 ],
                                 "unittitle": {
@@ -16341,7 +16803,8 @@
                                     {
                                         "value": "1934-1958",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1934/1958"
                                     }
                                 ],
                                 "unittitle": {
@@ -16402,7 +16865,8 @@
                                     {
                                         "value": "1957-1958",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1957/1958"
                                     }
                                 ],
                                 "unittitle": {
@@ -16433,7 +16897,8 @@
                                     {
                                         "value": "1950s",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1950/1959"
                                     }
                                 ],
                                 "unittitle": {
@@ -16508,7 +16973,8 @@
                                     {
                                         "value": "Undated",
                                         "type": "inclusive",
-                                        "datechar": "creation"
+                                        "datechar": "creation",
+                                        "normal": "1950/1990"
                                     }
                                 ],
                                 "unitid": "cuid853",
@@ -16539,7 +17005,8 @@
                             {
                                 "value": "1923-1999",
                                 "type": "inclusive",
-                                "datechar": "creation"
+                                "datechar": "creation",
+                                "normal": "1923/1999"
                             }
                         ],
                         "unittitle": {

--- a/ead/testdata/xmlorder/omega-ead-test-order.json
+++ b/ead/testdata/xmlorder/omega-ead-test-order.json
@@ -459,11 +459,13 @@
             "unitdate": [
                 {
                     "value": "2016-2021, undated",
-                    "type": "inclusive"
+                    "type": "inclusive",
+                    "normal": "2016/2021"
                 },
                 {
                     "value": "2020-2021, undated",
-                    "type": "bulk"
+                    "type": "bulk",
+                    "normal": "2020/2021"
                 }
             ],
             "unitid": "MOS.2021",
@@ -979,7 +981,8 @@
                                                             "did": {
                                                                 "unitdate": [
                                                                     {
-                                                                        "value": "1981-08-31"
+                                                                        "value": "1981-08-31",
+                                                                        "normal": "1981-08-31/1981-08-31"
                                                                     }
                                                                 ],
                                                                 "unittitle": {
@@ -1208,7 +1211,8 @@
                                                         "unitdate": [
                                                             {
                                                                 "value": "2020",
-                                                                "type": "inclusive"
+                                                                "type": "inclusive",
+                                                                "normal": "2020/2020"
                                                             }
                                                         ],
                                                         "unitid": "mos_2021_6",
@@ -1871,7 +1875,8 @@
                                                 "unitdate": [
                                                     {
                                                         "value": "2015-2019",
-                                                        "type": "inclusive"
+                                                        "type": "inclusive",
+                                                        "normal": "2015/2019"
                                                     }
                                                 ],
                                                 "unitid": "mos_2021_5",
@@ -2534,7 +2539,8 @@
                                         "unitdate": [
                                             {
                                                 "value": "2017-2019",
-                                                "type": "inclusive"
+                                                "type": "inclusive",
+                                                "normal": "2017/2019"
                                             }
                                         ],
                                         "unitid": "mos_2021_4",
@@ -3194,7 +3200,8 @@
                                 "unitdate": [
                                     {
                                         "value": "2021",
-                                        "type": "inclusive"
+                                        "type": "inclusive",
+                                        "normal": "2021/2021"
                                     }
                                 ],
                                 "unitid": "mos_2021_3",
@@ -3782,7 +3789,8 @@
                                 ],
                                 "unitdate": [
                                     {
-                                        "value": "1981-09-02"
+                                        "value": "1981-09-02",
+                                        "normal": "1981-09-02/1981-09-02"
                                     }
                                 ],
                                 "unittitle": {
@@ -4003,7 +4011,8 @@
                         "unitdate": [
                             {
                                 "value": "2015-2016",
-                                "type": "inclusive"
+                                "type": "inclusive",
+                                "normal": "2015/2016"
                             }
                         ],
                         "unitid": "mos_2021_2",


### PR DESCRIPTION
## Overview
#### v0.22.0
  - add `Normal` to `UnitDate`
  - add custom marshaling for `UnitDate` using the following logic:
    - if there is a `Value`, then output the `Value`  
      else if the `<unitdate @normal>` attribute is populated,   
      then use the `@normal` attribute value converted as follows:  
      `@normal="dateA/dateB"`  
        if `dateA == dateB` then `Value = "dateA"`  
        if `dateA != dateB` then `Value = "dateA-dateB"`
