### PR TITLE
Feature/v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@
        and `DAO.Href` IS     a valid URL then `role = "external-link"`
        and `DAO.Href` IS NOT a valid URL then `role = "non-url"`
 
-  - remove UnitDate custom marshaling
-    Remove custom marshaling of UnitDate because the functionality  
-      required to properly process the UnitDate values is better  
-      performed in the FASB.
+  - remove `UnitDate` custom marshaling  
+    Remove custom marshaling of `UnitDate` because the functionality  
+      required to properly process the `UnitDate` values is better  
+      performed in the `FASB`.
 
 #### v0.22.0
   - add `Normal` to `UnitDate`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+#### v0.23.0
+  - Update `DAO MarshalJSON()` as follows:
+     if `DAO.Role` is empty,
+       and `DAO.Href` IS     a valid URL then `role = "external-link"`
+       and `DAO.Href` IS NOT a valid URL then `role = "non-url"`
+
+  - remove UnitDate custom marshaling
+    Remove custom marshaling of UnitDate because the functionality  
+      required to properly process the UnitDate values is better  
+      performed in the FASB.
+
 #### v0.22.0
   - add `Normal` to `UnitDate`
   - add custom marshaling for `UnitDate` using the following logic:

--- a/ead/ead.go
+++ b/ead/ead.go
@@ -5,7 +5,7 @@ package ead
 // Based on: "Data model for parsing EAD <archdesc> elements": https://jira.nyu.edu/jira/browse/FADESIGN-29.
 
 const (
-	Version = "v0.22.0"
+	Version = "v0.23.0"
 )
 
 type EAD struct {

--- a/ead/ead_test.go
+++ b/ead/ead_test.go
@@ -239,10 +239,10 @@ func TestUpdatePubInfo(t *testing.T) {
 	})
 }
 
-func TestBarcodeRemovalFromLabels(t *testing.T) {
+func TestBarcodeRemovalFromLabelsAndNonURLRole(t *testing.T) {
 	var params iJSONTestParams
 
-	params.TestName = "Barcode Removal from Labels"
+	params.TestName = "Barcode Removal from Labels and Non-URL Role"
 	params.EADFilePath = filepath.Join(falesTestFixturePath, "mss_460.xml")
 	params.JSONReferenceFilePath = filepath.Join(falesTestFixturePath, "mss_460.json")
 	params.JSONErrorFilePath = "./testdata/tmp/failing-test-barcode-removal.json"

--- a/ead/generate.go
+++ b/ead/generate.go
@@ -138,7 +138,7 @@ func writeConvertTextWithTagsCodeToBuffer(w *bytes.Buffer) {
 		"Title":      "getConvertedTextWithTagsNoLBConversion",
 		// Do not add TitleProper because it requires custom marshaling.
 		// Do not add TitleStmt   because it requires custom marshaling.
-		// Do not add UnitDate    because it requires custom marshaling.
+		"UnitDate":  "getConvertedTextWithTags",
 		"UnitTitle": "getConvertedTextWithTags",
 	}
 

--- a/ead/marshaljson-generated.go
+++ b/ead/marshaljson-generated.go
@@ -469,6 +469,28 @@ func (title *Title) MarshalJSON() ([]byte, error) {
 	return jsonData, nil
 }
 
+func (unitdate *UnitDate) MarshalJSON() ([]byte, error) {
+	type UnitDateWithTags UnitDate
+
+	result, err := getConvertedTextWithTags(unitdate.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonData, err := json.Marshal(&struct {
+		Value string `json:"value,omitempty"`
+		*UnitDateWithTags
+	}{
+		Value:            string(result),
+		UnitDateWithTags: (*UnitDateWithTags)(unitdate),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return jsonData, nil
+}
+
 func (unittitle *UnitTitle) MarshalJSON() ([]byte, error) {
 	type UnitTitleWithTags UnitTitle
 

--- a/ead/marshaljson.go
+++ b/ead/marshaljson.go
@@ -3,6 +3,7 @@ package ead
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 )
@@ -166,11 +167,17 @@ func (indexEntry *IndexEntry) MarshalJSON() ([]byte, error) {
 }
 
 // set blank DAO Role attributes to "external-link"
+// if a DAO has a non-URL HREF, then set the role to "non-url"
 func (dao *DAO) MarshalJSON() ([]byte, error) {
 	// if DAO Role is empty, set it to external link
 	type DAOAlias DAO
 	if len(strings.TrimSpace(string(dao.Role))) == 0 {
 		dao.Role = "external-link"
+	}
+
+	_, err := url.ParseRequestURI(string(dao.Href))
+	if err != nil {
+		dao.Role = "non-url"
 	}
 
 	return json.Marshal(&struct {

--- a/ead/marshaljson.go
+++ b/ead/marshaljson.go
@@ -2,14 +2,14 @@ package ead
 
 import (
 	"encoding/json"
-	"fmt"
+//	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
 )
 
-var unitDateNormalRegexp = regexp.MustCompile(`(.+)/(.+)`)
-var unitDateNormalExpectedStringSubmatchCount = 3
+// var unitDateNormalRegexp = regexp.MustCompile(`(.+)/(.+)`)
+// var unitDateNormalExpectedStringSubmatchCount = 3
 
 // Note that this custom marshalling for DID will prevent PhysDesc from having a Value field
 // that is all whitespace if Extent is nil, but won't prevent PhysDesc from having
@@ -250,53 +250,53 @@ func (fnwh *FormattedNoteWithHead) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (unitdate *UnitDate) MarshalJSON() ([]byte, error) {
-	type UnitDateWithTags UnitDate
+// func (unitdate *UnitDate) MarshalJSON() ([]byte, error) {
+// 	type UnitDateWithTags UnitDate
 
-	result, err := getConvertedTextWithTags(unitdate.Value)
-	if err != nil {
-		return nil, err
-	}
+// 	result, err := getConvertedTextWithTags(unitdate.Value)
+// 	if err != nil {
+// 		return nil, err
+// 	}
 
-	// clean up any blank space
-	result = []byte(strings.TrimSpace(string(result)))
+// 	// clean up any blank space
+// 	result = []byte(strings.TrimSpace(string(result)))
 
-	// if result is empty...
-	if len(result) == 0 {
-		// check if we have a date value in Normal
-		if len(strings.TrimSpace(string(unitdate.Normal))) == 0 {
-			// nothing here, so omit this unitdate by setting the
-			// unitdate variable to an empty struct, which will
-			// be omitted during marshaling
-			unitdate = &UnitDate{}
-		} else {
-			// ok, we found something. Let's convert the value...
-			matches := unitDateNormalRegexp.FindStringSubmatch(string(unitdate.Normal))
+// 	// if result is empty...
+// 	if len(result) == 0 {
+// 		// check if we have a date value in Normal
+// 		if len(strings.TrimSpace(string(unitdate.Normal))) == 0 {
+// 			// nothing here, so omit this unitdate by setting the
+// 			// unitdate variable to an empty struct, which will
+// 			// be omitted during marshaling
+// 			unitdate = &UnitDate{}
+// 		} else {
+// 			// ok, we found something. Let's convert the value...
+// 			matches := unitDateNormalRegexp.FindStringSubmatch(string(unitdate.Normal))
 
-			if len(matches) < unitDateNormalExpectedStringSubmatchCount {
-				return nil, fmt.Errorf("problem parsing UnitDate.Normal")
-			}
-			// extract the values and configure result accordingly
-			dateA := matches[1]
-			dateB := matches[2]
+// 			if len(matches) < unitDateNormalExpectedStringSubmatchCount {
+// 				return nil, fmt.Errorf("problem parsing UnitDate.Normal")
+// 			}
+// 			// extract the values and configure result accordingly
+// 			dateA := matches[1]
+// 			dateB := matches[2]
 
-			if dateA == dateB {
-				result = []byte(dateA)
-			} else {
-				result = []byte(dateA + "-" + dateB)
-			}
-		}
-	}
-	jsonData, err := json.Marshal(&struct {
-		Value string `json:"value,omitempty"`
-		*UnitDateWithTags
-	}{
-		Value:            string(result),
-		UnitDateWithTags: (*UnitDateWithTags)(unitdate),
-	})
-	if err != nil {
-		return nil, err
-	}
+// 			if dateA == dateB {
+// 				result = []byte(dateA)
+// 			} else {
+// 				result = []byte(dateA + "-" + dateB)
+// 			}
+// 		}
+// 	}
+// 	jsonData, err := json.Marshal(&struct {
+// 		Value string `json:"value,omitempty"`
+// 		*UnitDateWithTags
+// 	}{
+// 		Value:            string(result),
+// 		UnitDateWithTags: (*UnitDateWithTags)(unitdate),
+// 	})
+// 	if err != nil {
+// 		return nil, err
+// 	}
 
-	return jsonData, nil
-}
+// 	return jsonData, nil
+// }

--- a/ead/marshaljson.go
+++ b/ead/marshaljson.go
@@ -2,7 +2,7 @@ package ead
 
 import (
 	"encoding/json"
-//	"fmt"
+	//	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
@@ -167,17 +167,19 @@ func (indexEntry *IndexEntry) MarshalJSON() ([]byte, error) {
 }
 
 // set blank DAO Role attributes to "external-link"
-// if a DAO has a non-URL HREF, then set the role to "non-url"
+// if a DAO does not have a role, and has a non-URL HREF, then set the role to "non-url"
 func (dao *DAO) MarshalJSON() ([]byte, error) {
-	// if DAO Role is empty, set it to external link
 	type DAOAlias DAO
+
+	// if DAO Role is empty,
+	//    and DAO.Href is a valid URL then role = "external-link"
+	//    and DAO.Href is NOT a valid URL then role = "non-url"
 	if len(strings.TrimSpace(string(dao.Role))) == 0 {
 		dao.Role = "external-link"
-	}
-
-	_, err := url.ParseRequestURI(string(dao.Href))
-	if err != nil {
-		dao.Role = "non-url"
+		_, err := url.ParseRequestURI(string(dao.Href))
+		if err != nil {
+			dao.Role = "non-url"
+		}
 	}
 
 	return json.Marshal(&struct {

--- a/ead/testdata/fales/mss_460.json
+++ b/ead/testdata/fales/mss_460.json
@@ -1048,7 +1048,7 @@
                                     {
                                         "actuate": "onRequest",
                                         "href": "FA_MSS_460_ER_9",
-                                        "role": "external-link",
+                                        "role": "non-url",
                                         "show": "new",
                                         "title": "Inventories",
                                         "type": "simple",

--- a/ead/testdata/tamwag/mos_2021.json
+++ b/ead/testdata/tamwag/mos_2021.json
@@ -468,23 +468,21 @@
                     "normal": "1910/1910"
                 },
                 {
-                    "value": "1977-2000",
                     "type": "inclusive",
                     "normal": "1977/2000"
                 },
                 {
-                    "value": "2013",
                     "datechar": "digitized",
                     "normal": "2013/2013"
                 },
-                {},
                 {
-                    "value": "1914-2014",
+                    "datechar": "digitized"
+                },
+                {
                     "datechar": "digitized",
                     "normal": "1914/2014"
                 },
                 {
-                    "value": "2018-02-08",
                     "datechar": "digitized",
                     "normal": "2018-02-08/2018-02-08"
                 }


### PR DESCRIPTION
## Overview
#### v0.23.0
  - Update `DAO MarshalJSON()` as follows:
     if `DAO.Role` is empty,
       and `DAO.Href` IS     a valid URL then `role = "external-link"`
       and `DAO.Href` IS NOT a valid URL then `role = "non-url"`

  - remove `UnitDate` custom marshaling
    Remove custom marshaling of `UnitDate` because the functionality  
      required to properly process the `UnitDate` values is better  
      performed in the `FASB`.

