### PR TITLE
feature/fabify: remove <unitid @aspace_uri>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-#### v0.31.0-20240131T2126Z
+#### v0.31.0-pre+001
   - Update `modify.FABifyEAD` code to remove the
 	`<ead><archdesc><did><unitid @type="aspace_uri">` element from the
 	EAD.  This is required because the FAB is currently appending the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-#### v0.31.0-20240131T2112Z
+#### v0.31.0-20240131T2126Z
   - Update `modify.FABifyEAD` code to remove the
 	`<ead><archdesc><did><unitid @type="aspace_uri">` element from the
 	EAD.  This is required because the FAB is currently appending the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-#### v0.31.0-pre+001
+#### v0.31.0
   - Update `modify.FABifyEAD` code to remove the
 	`<ead><archdesc><did><unitid @type="aspace_uri">` element from the
 	EAD.  This is required because the FAB is currently appending the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+#### v0.31.0-20240131T2112Z
+  - Update `modify.FABifyEAD` code to remove the
+	`<ead><archdesc><did><unitid @type="aspace_uri">` element from the
+	EAD.  This is required because the FAB is currently appending the
+	`aspace_uri` value to the `Collection call no:` result, e.g.,
+	`Collection call no: MC.109/repositories/6/resources/1930`
+
 #### v0.30.0
   - Add `al Mawrid Arab Art Archive, NYU Abu Dhabi` as a valid repository name
 

--- a/ead/ead.go
+++ b/ead/ead.go
@@ -5,7 +5,7 @@ package ead
 // Based on: "Data model for parsing EAD <archdesc> elements": https://jira.nyu.edu/jira/browse/FADESIGN-29.
 
 const (
-	Version = "v0.30.0"
+	Version = "v0.31.0-20240131T2126Z"
 )
 
 type EAD struct {

--- a/ead/ead.go
+++ b/ead/ead.go
@@ -5,7 +5,7 @@ package ead
 // Based on: "Data model for parsing EAD <archdesc> elements": https://jira.nyu.edu/jira/browse/FADESIGN-29.
 
 const (
-	Version = "v0.31.0-pre+001"
+	Version = "v0.31.0"
 )
 
 type EAD struct {

--- a/ead/ead.go
+++ b/ead/ead.go
@@ -5,7 +5,7 @@ package ead
 // Based on: "Data model for parsing EAD <archdesc> elements": https://jira.nyu.edu/jira/browse/FADESIGN-29.
 
 const (
-	Version = "v0.31.0-20240131T2126Z"
+	Version = "v0.31.0-pre+001"
 )
 
 type EAD struct {

--- a/ead/modify/modify.go
+++ b/ead/modify/modify.go
@@ -14,14 +14,15 @@ import (
 // discovery system (https://github.com/NYULibraries/specialcollections).
 //
 // Those modifications are:
-// 1.) change <origination label="Creator">
+// 1.) change <origination label="Creator"> to <origination label="creator">
 //
-//	to     <origination label="creator">
+// 2.) remove the selected <unitid @type="aspace_uri"> element(s)
 //
-// 2.) for <container> hierarchies, set all subcontainer @parent
+// 3.) for <container> hierarchies, set all subcontainer @parent
+//     attribute values = to the @id of the root container
+//     and delete the @id attribute from all subcontainers
 //
-//	attribute values = to the @id of the root container
-//	and delete the @id attribute from all subcontainers
+
 func FABifyEAD(data []byte) (string, []string) {
 
 	var errors = []string{}
@@ -55,58 +56,116 @@ func FABifyEAD(data []byte) (string, []string) {
 		return "", append(errors, err.Error())
 	}
 
+	updateOriginationCreatorAttribute(ctx)
+	errors = append(errors, removeUnitidTypeASpaceURI(ctx)...)
+	if len(errors) > 0 {
+		return "", errors
+	}
+	errors = updateContainerHierarchies(ctx)
+	if len(errors) > 0 {
+		return "", errors
+	}
+
+	//------------------------------------------------------------------------------
+	// 1.) change <origination label="Creator"> to <origination label="creator">
+	//------------------------------------------------------------------------------
 	// find all nodes where <origination @label="Creator"> so that
 	// "Creator" can be converted to the FAB-compatible value "creator"
-	exprString := `//_:origination/@label[.='Creator']`
-	nodes := xpath.NodeList(ctx.Find(exprString))
-	for _, n := range nodes {
-		n.SetNodeValue("creator")
-	}
+	/*
+		exprString := `//_:origination/@label[.='Creator']`
+		nodes := xpath.NodeList(ctx.Find(exprString))
+		for _, n := range nodes {
+			n.SetNodeValue("creator")
+		}
+	*/
 
-	// rootIDs is a slice of strings containing the @id attribute values for all root containers
-	var rootIDs []string
+	//------------------------------------------------------------------------------
+	// 2.) remove the selected <unitid @type="aspace_uri"> element(s)
+	//------------------------------------------------------------------------------
+	// find the selected attribute nodes where <unitid @type="aspace_uri">
+	// then find the parent element node and delete it
 
-	// subContainers is a map keyed by the @parent attribute values of subcontainers
-	subContainers := make(map[string]types.Node)
+	// *** UNUSED ***: this expression finds ALL unitid nodes with @type="aspace_uri"
+	//	               exprString = `//_:unitid/@type['aspace_uri']`
 
-	// find all containers and divide them between root containers and subcontainers
-	exprString = `//_:container`
-	containerNodes := xpath.NodeList(ctx.Find(exprString))
-	for _, containerNode := range containerNodes {
+	// this expression finds only the collection-level unitid node with @type="aspace_uri"
+	/*
+		exprString := `//_:ead/_:archdesc/_:did/_:unitid/@type['aspace_uri']`
+		nodes := xpath.NodeList(ctx.Find(exprString))
 
-		// if a containerNode has a @parent attribute, then it is a subcontainer node
-		// otherwise it is a root container node
-		parentAttributeNode, err := containerNode.(types.Element).GetAttribute("parent")
-
-		if err == nil {
-			// subcontainer branch
-			parentID := parentAttributeNode.NodeValue()
-			if subContainers[parentID] != nil {
-				errors = append(errors, fmt.Sprintf("error: detected multiple subcontainers with the same parentID: %s", parentID))
-				errors = append(errors, "check if this EAD has already been \"FABified\"")
-				return "", append(errors, err.Error())
-			}
-			subContainers[parentID] = containerNode
-		} else {
-			// root container branch
-			idAttributeNode, err := containerNode.(types.Element).GetAttribute("id")
+		for _, n := range nodes {
+			// get the parent element node of the selected attribute node
+			element, err := n.ParentNode()
 			if err != nil {
-				errors = append(errors, "error: root container @id attribute is missing")
+				errors = append(errors, "Failed to retrieve <unitid> node")
 				return "", append(errors, err.Error())
 			}
-			rootIDs = append(rootIDs, idAttributeNode.NodeValue())
-		}
-	}
 
-	// process all subcontainer hierarchies
-	for _, rootID := range rootIDs {
-		err := updateSubContainersUsingMap(subContainers, rootID, rootID)
-		if err != nil {
-			errors = append(errors, "error updating subcontainers of root container with @id=\"%s\"", rootID)
-			return "", append(errors, err.Error())
-		}
-	}
+			// get the parent element node of the <unitid> element node
+			parent, err := element.ParentNode()
+			if err != nil {
+				errors = append(errors, "Failed to retrieve <unitid> parent node")
+				return "", append(errors, err.Error())
+			}
 
+			// remove the <unitid> element node from its parent
+			err = parent.RemoveChild(element)
+			if err != nil {
+				errors = append(errors, "Failed to delete <unitid @type='aspace_uri'> node")
+				return "", append(errors, err.Error())
+			}
+		}
+	*/
+	//------------------------------------------------------------------------------
+	// 3.) for <container> hierarchies, set all subcontainer @parent
+	//     attribute values = to the @id of the root container
+	//     and delete the @id attribute from all subcontainers
+	//------------------------------------------------------------------------------
+	// rootIDs is a slice of strings containing the @id attribute values for all root containers
+	/*
+		var rootIDs []string
+
+		// subContainers is a map keyed by the @parent attribute values of subcontainers
+		subContainers := make(map[string]types.Node)
+
+		// find all containers and divide them between root containers and subcontainers
+		exprString := `//_:container`
+		containerNodes := xpath.NodeList(ctx.Find(exprString))
+		for _, containerNode := range containerNodes {
+
+			// if a containerNode has a @parent attribute, then it is a subcontainer node
+			// otherwise it is a root container node
+			parentAttributeNode, err := containerNode.(types.Element).GetAttribute("parent")
+
+			if err == nil {
+				// subcontainer branch
+				parentID := parentAttributeNode.NodeValue()
+				if subContainers[parentID] != nil {
+					errors = append(errors, fmt.Sprintf("error: detected multiple subcontainers with the same parentID: %s", parentID))
+					errors = append(errors, "check if this EAD has already been \"FABified\"")
+					return "", append(errors, err.Error())
+				}
+				subContainers[parentID] = containerNode
+			} else {
+				// root container branch
+				idAttributeNode, err := containerNode.(types.Element).GetAttribute("id")
+				if err != nil {
+					errors = append(errors, "error: root container @id attribute is missing")
+					return "", append(errors, err.Error())
+				}
+				rootIDs = append(rootIDs, idAttributeNode.NodeValue())
+			}
+		}
+
+		// process all subcontainer hierarchies
+		for _, rootID := range rootIDs {
+			err := updateSubContainersUsingMap(subContainers, rootID, rootID)
+			if err != nil {
+				errors = append(errors, "error updating subcontainers of root container with @id=\"%s\"", rootID)
+				return "", append(errors, err.Error())
+			}
+		}
+	*/
 	return doc.String(), errors
 }
 
@@ -134,4 +193,97 @@ func updateSubContainersUsingMap(subContainers map[string]types.Node, parentID s
 
 	err = updateSubContainersUsingMap(subContainers, id, rootID)
 	return err
+}
+
+func updateOriginationCreatorAttribute(ctx *xpath.Context) error {
+	// find all nodes where <origination @label="Creator"> so that
+	// "Creator" can be converted to the FAB-compatible value "creator"
+	exprString := `//_:origination/@label[.='Creator']`
+	nodes := xpath.NodeList(ctx.Find(exprString))
+	for _, n := range nodes {
+		n.SetNodeValue("creator")
+	}
+
+	return nil
+}
+
+func removeUnitidTypeASpaceURI(ctx *xpath.Context) []string {
+	var errors = []string{}
+	// *** UNUSED ***: this expression finds ALL unitid nodes with @type="aspace_uri"
+	//	               exprString = `//_:unitid/@type['aspace_uri']`
+
+	// this expression finds only the collection-level unitid node with @type="aspace_uri"
+	exprString := `//_:ead/_:archdesc/_:did/_:unitid/@type['aspace_uri']`
+	nodes := xpath.NodeList(ctx.Find(exprString))
+
+	for _, n := range nodes {
+		// get the parent element node of the selected attribute node
+		element, err := n.ParentNode()
+		if err != nil {
+			errors = append(errors, "Failed to retrieve <unitid> node")
+			return append(errors, err.Error())
+		}
+
+		// get the parent element node of the <unitid> element node
+		parent, err := element.ParentNode()
+		if err != nil {
+			errors = append(errors, "Failed to retrieve <unitid> parent node")
+			return append(errors, err.Error())
+		}
+
+		// remove the <unitid> element node from its parent
+		err = parent.RemoveChild(element)
+		if err != nil {
+			errors = append(errors, "Failed to delete <unitid @type='aspace_uri'> node")
+			return append(errors, err.Error())
+		}
+	}
+	return errors
+}
+
+func updateContainerHierarchies(ctx *xpath.Context) []string {
+	var errors = []string{}
+	var rootIDs []string
+
+	// subContainers is a map keyed by the @parent attribute values of subcontainers
+	subContainers := make(map[string]types.Node)
+
+	// find all containers and divide them between root containers and subcontainers
+	exprString := `//_:container`
+	containerNodes := xpath.NodeList(ctx.Find(exprString))
+	for _, containerNode := range containerNodes {
+
+		// if a containerNode has a @parent attribute, then it is a subcontainer node
+		// otherwise it is a root container node
+		parentAttributeNode, err := containerNode.(types.Element).GetAttribute("parent")
+
+		if err == nil {
+			// subcontainer branch
+			parentID := parentAttributeNode.NodeValue()
+			if subContainers[parentID] != nil {
+				errors = append(errors, fmt.Sprintf("error: detected multiple subcontainers with the same parentID: %s", parentID))
+				errors = append(errors, "check if this EAD has already been \"FABified\"")
+				return append(errors, err.Error())
+			}
+			subContainers[parentID] = containerNode
+		} else {
+			// root container branch
+			idAttributeNode, err := containerNode.(types.Element).GetAttribute("id")
+			if err != nil {
+				errors = append(errors, "error: root container @id attribute is missing")
+				return append(errors, err.Error())
+			}
+			rootIDs = append(rootIDs, idAttributeNode.NodeValue())
+		}
+	}
+
+	// process all subcontainer hierarchies
+	for _, rootID := range rootIDs {
+		err := updateSubContainersUsingMap(subContainers, rootID, rootID)
+		if err != nil {
+			errors = append(errors, "error updating subcontainers of root container with @id=\"%s\"", rootID)
+			return append(errors, err.Error())
+		}
+	}
+	return errors
 }

--- a/ead/modify/modify.go
+++ b/ead/modify/modify.go
@@ -56,7 +56,9 @@ func FABifyEAD(data []byte) (string, []string) {
 		return "", append(errors, err.Error())
 	}
 
+	// update the EAD
 	updateOriginationCreatorAttribute(ctx)
+
 	errors = append(errors, removeUnitidTypeASpaceURI(ctx)...)
 	if len(errors) > 0 {
 		return "", errors
@@ -66,106 +68,6 @@ func FABifyEAD(data []byte) (string, []string) {
 		return "", errors
 	}
 
-	//------------------------------------------------------------------------------
-	// 1.) change <origination label="Creator"> to <origination label="creator">
-	//------------------------------------------------------------------------------
-	// find all nodes where <origination @label="Creator"> so that
-	// "Creator" can be converted to the FAB-compatible value "creator"
-	/*
-		exprString := `//_:origination/@label[.='Creator']`
-		nodes := xpath.NodeList(ctx.Find(exprString))
-		for _, n := range nodes {
-			n.SetNodeValue("creator")
-		}
-	*/
-
-	//------------------------------------------------------------------------------
-	// 2.) remove the selected <unitid @type="aspace_uri"> element(s)
-	//------------------------------------------------------------------------------
-	// find the selected attribute nodes where <unitid @type="aspace_uri">
-	// then find the parent element node and delete it
-
-	// *** UNUSED ***: this expression finds ALL unitid nodes with @type="aspace_uri"
-	//	               exprString = `//_:unitid/@type['aspace_uri']`
-
-	// this expression finds only the collection-level unitid node with @type="aspace_uri"
-	/*
-		exprString := `//_:ead/_:archdesc/_:did/_:unitid/@type['aspace_uri']`
-		nodes := xpath.NodeList(ctx.Find(exprString))
-
-		for _, n := range nodes {
-			// get the parent element node of the selected attribute node
-			element, err := n.ParentNode()
-			if err != nil {
-				errors = append(errors, "Failed to retrieve <unitid> node")
-				return "", append(errors, err.Error())
-			}
-
-			// get the parent element node of the <unitid> element node
-			parent, err := element.ParentNode()
-			if err != nil {
-				errors = append(errors, "Failed to retrieve <unitid> parent node")
-				return "", append(errors, err.Error())
-			}
-
-			// remove the <unitid> element node from its parent
-			err = parent.RemoveChild(element)
-			if err != nil {
-				errors = append(errors, "Failed to delete <unitid @type='aspace_uri'> node")
-				return "", append(errors, err.Error())
-			}
-		}
-	*/
-	//------------------------------------------------------------------------------
-	// 3.) for <container> hierarchies, set all subcontainer @parent
-	//     attribute values = to the @id of the root container
-	//     and delete the @id attribute from all subcontainers
-	//------------------------------------------------------------------------------
-	// rootIDs is a slice of strings containing the @id attribute values for all root containers
-	/*
-		var rootIDs []string
-
-		// subContainers is a map keyed by the @parent attribute values of subcontainers
-		subContainers := make(map[string]types.Node)
-
-		// find all containers and divide them between root containers and subcontainers
-		exprString := `//_:container`
-		containerNodes := xpath.NodeList(ctx.Find(exprString))
-		for _, containerNode := range containerNodes {
-
-			// if a containerNode has a @parent attribute, then it is a subcontainer node
-			// otherwise it is a root container node
-			parentAttributeNode, err := containerNode.(types.Element).GetAttribute("parent")
-
-			if err == nil {
-				// subcontainer branch
-				parentID := parentAttributeNode.NodeValue()
-				if subContainers[parentID] != nil {
-					errors = append(errors, fmt.Sprintf("error: detected multiple subcontainers with the same parentID: %s", parentID))
-					errors = append(errors, "check if this EAD has already been \"FABified\"")
-					return "", append(errors, err.Error())
-				}
-				subContainers[parentID] = containerNode
-			} else {
-				// root container branch
-				idAttributeNode, err := containerNode.(types.Element).GetAttribute("id")
-				if err != nil {
-					errors = append(errors, "error: root container @id attribute is missing")
-					return "", append(errors, err.Error())
-				}
-				rootIDs = append(rootIDs, idAttributeNode.NodeValue())
-			}
-		}
-
-		// process all subcontainer hierarchies
-		for _, rootID := range rootIDs {
-			err := updateSubContainersUsingMap(subContainers, rootID, rootID)
-			if err != nil {
-				errors = append(errors, "error updating subcontainers of root container with @id=\"%s\"", rootID)
-				return "", append(errors, err.Error())
-			}
-		}
-	*/
 	return doc.String(), errors
 }
 

--- a/ead/modify/modify_test.go
+++ b/ead/modify/modify_test.go
@@ -17,7 +17,7 @@ func failOnError(t *testing.T, err error, label string) {
 }
 
 func TestFABifyEAD(t *testing.T) {
-	t.Run("Modify EAD For Discovery System (FAB)", func(t *testing.T) {
+	t.Run("Modify EAD For Discovery System (FAB): creator, location", func(t *testing.T) {
 
 		testFixturePath := filepath.Join(".", "testdata")
 		testTmpDirPath := filepath.Join(testFixturePath, "tmp")
@@ -39,6 +39,36 @@ func TestFABifyEAD(t *testing.T) {
 
 		if !bytes.Equal(want, got) {
 			errTmpFile := filepath.Join(testTmpDirPath, "ERR-modify-ead.xml")
+			err = os.WriteFile(errTmpFile, got, 0644)
+			failOnError(t, err, fmt.Sprintf("Unexpected error writing %s", errTmpFile))
+
+			errMsg := fmt.Sprintf("The modified EAD does not match the reference file.\ndiff %s %s", errTmpFile, referenceFile)
+			t.Errorf(errMsg)
+		}
+	})
+
+	t.Run("Modify EAD For Discovery System (FAB): unitid @aspace_uri", func(t *testing.T) {
+
+		testFixturePath := filepath.Join(".", "testdata")
+		testTmpDirPath := filepath.Join(testFixturePath, "tmp")
+
+		sourceFile := filepath.Join(testFixturePath, "unitid-aspace_uri-input.xml")
+		referenceFile := filepath.Join(testFixturePath, "unitid-aspace_uri-expected.xml")
+
+		EADXML, err := os.ReadFile(sourceFile)
+		failOnError(t, err, "Unexpected error")
+
+		doc, errors := FABifyEAD(EADXML)
+		if len(errors) != 0 {
+			failOnError(t, fmt.Errorf("%s", strings.Join(errors, "\n")), "problem modifying EAD")
+		}
+
+		got := []byte(doc)
+		want, err := os.ReadFile(referenceFile)
+		failOnError(t, err, "Unexpected error reading reference file")
+
+		if !bytes.Equal(want, got) {
+			errTmpFile := filepath.Join(testTmpDirPath, "ERR-unitid-aspace_uri-ead.xml")
 			err = os.WriteFile(errTmpFile, got, 0644)
 			failOnError(t, err, fmt.Sprintf("Unexpected error writing %s", errTmpFile))
 

--- a/ead/modify/testdata/unitid-aspace_uri-expected.xml
+++ b/ead/modify/testdata/unitid-aspace_uri-expected.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ead xmlns="urn:isbn:1-931666-22-9" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd">
+  <eadheader countryencoding="iso3166-1" dateencoding="iso8601" langencoding="iso639-2b" repositoryencoding="iso15511">
+    <eadid countrycode="US" mainagencycode="US-NyNyUA" url="https://findingaids.library.nyu.edu/archives/mc_109/">mc_109</eadid>
+    <filedesc>
+      <titlestmt>
+        <titleproper>Guide to the Thomas Clark Pollock Papers <num>MC.109</num></titleproper>
+        <author>Jacqueline Rider</author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher>New York University Archives</publisher>
+        <p>
+          <date>3-10-2011</date>
+        </p>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>This finding aid was produced using ArchivesSpace on <date>2023-11-10 15:53:29 -0500</date>.</creation>
+      <langusage>Finding aid written in English</langusage>
+      <descrules>Describing Archives: A Content Standard</descrules>
+    </profiledesc>
+    <revisiondesc>
+      <change>
+        <date>September 2019</date>
+        <item>Updated by Jacqueline Rider for compliance with DACS and ACM Required Elements for Archival Description</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <archdesc level="collection">
+    <did>
+      <repository>
+        <corpname>New York University Archives</corpname>
+      </repository>
+      <unittitle>Thomas Clark Pollock Papers</unittitle>
+      <origination label="creator">
+        <persname source="naf">Pollock, Thomas Clark, 1902-1988</persname>
+      </origination>
+      <unitid>MC.109</unitid>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">0.25 Linear Feet</extent>
+        <extent altrender="carrier">in one half manuscript box</extent>
+      </physdesc>
+      <unitdate datechar="creation" normal="1963/1971" type="inclusive">1963-1971</unitdate>
+      <physloc id="aspace_c39575d9121d14a5edc6e0f756f24227">Materials are stored offsite and advance notice is required for use. Please request materials at least two business days prior to your research visit to coordinate access.</physloc>
+      <abstract id="aspace_bec536610173689324ba6b97bdb475f6">Thomas Clark Pollock (1902-1988) served New York University (NYU) as an education and English professor and as a department chair and dean. The collection consists of materials relating to Pollock's proposed 20th-century history of NYU.</abstract>
+      <langmaterial id="aspace_b20575192f29a0d1a925a1e1c7a02020">Materials are in English.</langmaterial>
+    </did>
+    <accessrestrict id="aspace_9c76db1073f1c2e4dce654438a88b8a2">
+      <head>Conditions Governing Access</head>
+      <p>Materials are open without restrictions.</p>
+    </accessrestrict>
+    <scopecontent id="aspace_14571b72c211595d895fc39a9d80aa9e">
+      <head>Scope and Contents</head>
+      <p>The collection consists of papers, published articles, drafts, correspondence and duplicates relating to Pollock's proposed 20th-century history of NYU.  Many of the papers are summaries of interviews Pollock conducted with faculty and administrators.</p>
+      <p>Pollock's manuscript, dated January 17, 1969, contains the results of his research and reading while he was studying background of the University for his proposed history of NYU. Bayrd Still, Pollock's successor as University Archivist, excerpted portions for the general reader and researcher under the title, "New York University in the Nineteenth Century."</p>
+    </scopecontent>
+    <arrangement id="aspace_6d13fee283cb4339a6e0f9c5f6249bf9">
+      <head>Arrangement</head>
+      <p>Items are arranged at the folder level.</p>
+    </arrangement>
+    <bioghist id="aspace_e5634c7321724369205f12357c30e92b">
+      <head>Biography</head>
+      <p>Thomas Clark Pollock (1902-1988) served on NYU's faculty and administration.  From 1941 to 1947, he was Professor of Education, becoming Chairman of the Department of English Education in 1944.  He was Professor of English and Dean of the Washington Square College of Arts and Science from 1947 to 1962.  In 1951, he took a one-year leave of absence from his deanship to become acting Provost of the University.  During that period he also served as Chief Administrator of the College of Dentistry.  From 1958 to 1959 he was Dean of the Graduate School of Arts and Science as well as Washington Square College.  In 1962 he was appointed Vice President and Secretary of the University.  In September 1967 he was appointed Archivist of the University, a position he held until March 1969.  He retired from NYU in 1970.</p>
+      <p>Pollock was awarded honorary degrees from Muskingum College and the Universities of Brazil and Bahia.</p>
+      <p>He wrote several books, including <emph render="italic">The Philadelphia Theatre in the Eighteenth Century, The Teaching of English Grammar in the Secondary Schools of New Jersey, The Nature of Literature, A Theory of Meaning Analyzed, The English Language in American Education</emph>, and <emph render="italic">Thomas Wolfe at Washington Square </emph>(with Oscar Cargill).  He was working on a 20th-century history of New York University at the time of his retirement.</p>
+    </bioghist>
+    <prefercite id="aspace_7c04e253b44b3d7e12a68af455d83e44">
+      <head>Preferred Citation</head>
+      <p>Identification of item, date (if known), T.C. Pollock Papers, MC 109, folder number, New York University Archives, New York University Libraries.</p>
+    </prefercite>
+    <userestrict id="aspace_7261c05166ab84c4148004e6a52161ca">
+      <head>Conditions Governing Use</head>
+      <p>Any rights (including copyright and related rights to publicity and privacy) held by the creator are maintained by New York University. Permission to publish or reproduce materials in this collection must be secured from New York University Archives, (212) 998-2646, university-archives@nyu.edu.</p>
+    </userestrict>
+    <acqinfo id="aspace_ce00559200da6557705f957c7647643b">
+      <head>Immediate Source of Acquisition</head>
+      <p>Materials found in collection; there is no documentation concerning the provenance of these materials.</p>
+    </acqinfo>
+    <processinfo id="aspace_f66c72a84bcb60af034e3d46b8030e77">
+      <head>Processing Information</head>
+      <p>Materials were placed in an archival box and folders.</p>
+    </processinfo>
+    <controlaccess>
+      <genreform source="aat">Manuscripts</genreform>
+      <genreform source="aat">Lecture notes.</genreform>
+      <subject source="lcsh">History.</subject>
+      <corpname authfilenumber="(lccn)n79052591" source="naf">New York University. Faculty of Arts and Science</corpname>
+      <corpname rules="dacs" source="local">New York University. Dean of Washington Square and University College</corpname>
+      <corpname authfilenumber="(lccn)n85271318" source="naf">New York University. College of Dentistry</corpname>
+      <corpname rules="dacs" source="local">New York University. Washington Square College of Arts and Science</corpname>
+      <corpname authfilenumber="(lccn)n80079860" source="naf">New York University. School of Education</corpname>
+      <corpname rules="dacs" source="local">New York University. Office of the Vice President and Secretary</corpname>
+    </controlaccess>
+    <dsc>
+      <c id="aspace_ref8" level="file">
+        <did>
+          <unittitle>New York University in the Nineteenth Century</unittitle>
+          <unitid type="aspace_uri">/repositories/6/archival_objects/594304</unitid>
+          <unitdate datechar="creation" normal="1969/1969" type="inclusive">1969</unitdate>
+          <langmaterial><language langcode="eng">English</language>.</langmaterial>
+          <container altrender="Manuscript box - Letter" id="aspace_9d7cb82870151a6bd11084a1e5284d15" label="Mixed Materials [31142063040987]" type="Box">1</container>
+          <container parent="aspace_9d7cb82870151a6bd11084a1e5284d15" type="Folder">1</container>
+        </did>
+      </c>
+      <c id="aspace_ref9" level="file">
+        <did>
+          <unittitle>Correspondence</unittitle>
+          <unitid type="aspace_uri">/repositories/6/archival_objects/594305</unitid>
+          <unitdate datechar="creation" normal="1966/1971" type="inclusive">1966-1971</unitdate>
+          <langmaterial><language langcode="eng">English</language>.</langmaterial>
+          <container altrender="Manuscript box - Letter" id="aspace_f762ef7b3b6f5b4a43b066e01bca7cfd" label="Mixed Materials [31142063040987]" type="Box">1</container>
+          <container parent="aspace_f762ef7b3b6f5b4a43b066e01bca7cfd" type="Folder">2</container>
+        </did>
+      </c>
+      <c id="aspace_ref10" level="file">
+        <did>
+          <unittitle>Duplicates of items in folders 1 and 4</unittitle>
+          <unitid type="aspace_uri">/repositories/6/archival_objects/594306</unitid>
+          <unitdate datechar="creation" normal="1963/1969" type="inclusive">1963-1969</unitdate>
+          <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
+          <container altrender="Manuscript box - Letter" id="aspace_edbab98ed95b8bdca0d8d7242adda487" label="Mixed Materials [31142063040987]" type="Box">1</container>
+          <container parent="aspace_edbab98ed95b8bdca0d8d7242adda487" type="Folder">3</container>
+        </did>
+      </c>
+      <c id="aspace_ref11" level="file">
+        <did>
+          <unittitle>Plans and research for a History of New York University </unittitle>
+          <unitid type="aspace_uri">/repositories/6/archival_objects/594307</unitid>
+          <unitdate datechar="creation" normal="1963/1969" type="inclusive">1963-1969</unitdate>
+          <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
+          <container altrender="Manuscript box - Letter" id="aspace_870e47ca566b9f03ed773a0f18edfeda" label="Mixed Materials [31142063040987]" type="Box">1</container>
+          <container parent="aspace_870e47ca566b9f03ed773a0f18edfeda" type="Folder">4</container>
+        </did>
+      </c>
+    </dsc>
+  </archdesc>
+</ead>

--- a/ead/modify/testdata/unitid-aspace_uri-expected.xml
+++ b/ead/modify/testdata/unitid-aspace_uri-expected.xml
@@ -36,6 +36,7 @@
         <persname source="naf">Pollock, Thomas Clark, 1902-1988</persname>
       </origination>
       <unitid>MC.109</unitid>
+      
       <physdesc altrender="whole">
         <extent altrender="materialtype spaceoccupied">0.25 Linear Feet</extent>
         <extent altrender="carrier">in one half manuscript box</extent>
@@ -95,7 +96,7 @@
       <c id="aspace_ref8" level="file">
         <did>
           <unittitle>New York University in the Nineteenth Century</unittitle>
-          <unitid type="aspace_uri">/repositories/6/archival_objects/594304</unitid>
+          
           <unitdate datechar="creation" normal="1969/1969" type="inclusive">1969</unitdate>
           <langmaterial><language langcode="eng">English</language>.</langmaterial>
           <container altrender="Manuscript box - Letter" id="aspace_9d7cb82870151a6bd11084a1e5284d15" label="Mixed Materials [31142063040987]" type="Box">1</container>
@@ -105,7 +106,7 @@
       <c id="aspace_ref9" level="file">
         <did>
           <unittitle>Correspondence</unittitle>
-          <unitid type="aspace_uri">/repositories/6/archival_objects/594305</unitid>
+          
           <unitdate datechar="creation" normal="1966/1971" type="inclusive">1966-1971</unitdate>
           <langmaterial><language langcode="eng">English</language>.</langmaterial>
           <container altrender="Manuscript box - Letter" id="aspace_f762ef7b3b6f5b4a43b066e01bca7cfd" label="Mixed Materials [31142063040987]" type="Box">1</container>
@@ -115,7 +116,7 @@
       <c id="aspace_ref10" level="file">
         <did>
           <unittitle>Duplicates of items in folders 1 and 4</unittitle>
-          <unitid type="aspace_uri">/repositories/6/archival_objects/594306</unitid>
+          
           <unitdate datechar="creation" normal="1963/1969" type="inclusive">1963-1969</unitdate>
           <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
           <container altrender="Manuscript box - Letter" id="aspace_edbab98ed95b8bdca0d8d7242adda487" label="Mixed Materials [31142063040987]" type="Box">1</container>
@@ -125,7 +126,7 @@
       <c id="aspace_ref11" level="file">
         <did>
           <unittitle>Plans and research for a History of New York University </unittitle>
-          <unitid type="aspace_uri">/repositories/6/archival_objects/594307</unitid>
+          
           <unitdate datechar="creation" normal="1963/1969" type="inclusive">1963-1969</unitdate>
           <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
           <container altrender="Manuscript box - Letter" id="aspace_870e47ca566b9f03ed773a0f18edfeda" label="Mixed Materials [31142063040987]" type="Box">1</container>

--- a/ead/modify/testdata/unitid-aspace_uri-expected.xml
+++ b/ead/modify/testdata/unitid-aspace_uri-expected.xml
@@ -96,7 +96,7 @@
       <c id="aspace_ref8" level="file">
         <did>
           <unittitle>New York University in the Nineteenth Century</unittitle>
-          
+          <unitid type="aspace_uri">/repositories/6/archival_objects/594304</unitid>
           <unitdate datechar="creation" normal="1969/1969" type="inclusive">1969</unitdate>
           <langmaterial><language langcode="eng">English</language>.</langmaterial>
           <container altrender="Manuscript box - Letter" id="aspace_9d7cb82870151a6bd11084a1e5284d15" label="Mixed Materials [31142063040987]" type="Box">1</container>
@@ -106,7 +106,7 @@
       <c id="aspace_ref9" level="file">
         <did>
           <unittitle>Correspondence</unittitle>
-          
+          <unitid type="aspace_uri">/repositories/6/archival_objects/594305</unitid>
           <unitdate datechar="creation" normal="1966/1971" type="inclusive">1966-1971</unitdate>
           <langmaterial><language langcode="eng">English</language>.</langmaterial>
           <container altrender="Manuscript box - Letter" id="aspace_f762ef7b3b6f5b4a43b066e01bca7cfd" label="Mixed Materials [31142063040987]" type="Box">1</container>
@@ -116,7 +116,7 @@
       <c id="aspace_ref10" level="file">
         <did>
           <unittitle>Duplicates of items in folders 1 and 4</unittitle>
-          
+          <unitid type="aspace_uri">/repositories/6/archival_objects/594306</unitid>
           <unitdate datechar="creation" normal="1963/1969" type="inclusive">1963-1969</unitdate>
           <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
           <container altrender="Manuscript box - Letter" id="aspace_edbab98ed95b8bdca0d8d7242adda487" label="Mixed Materials [31142063040987]" type="Box">1</container>
@@ -126,7 +126,7 @@
       <c id="aspace_ref11" level="file">
         <did>
           <unittitle>Plans and research for a History of New York University </unittitle>
-          
+          <unitid type="aspace_uri">/repositories/6/archival_objects/594307</unitid>
           <unitdate datechar="creation" normal="1963/1969" type="inclusive">1963-1969</unitdate>
           <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
           <container altrender="Manuscript box - Letter" id="aspace_870e47ca566b9f03ed773a0f18edfeda" label="Mixed Materials [31142063040987]" type="Box">1</container>

--- a/ead/modify/testdata/unitid-aspace_uri-input.xml
+++ b/ead/modify/testdata/unitid-aspace_uri-input.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ead xmlns="urn:isbn:1-931666-22-9" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd">
+  <eadheader countryencoding="iso3166-1" dateencoding="iso8601" langencoding="iso639-2b" repositoryencoding="iso15511">
+    <eadid countrycode="US" mainagencycode="US-NyNyUA" url="https://findingaids.library.nyu.edu/archives/mc_109/">mc_109</eadid>
+    <filedesc>
+      <titlestmt>
+        <titleproper>Guide to the Thomas Clark Pollock Papers <num>MC.109</num></titleproper>
+        <author>Jacqueline Rider</author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher>New York University Archives</publisher>
+        <p>
+          <date>3-10-2011</date>
+        </p>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>This finding aid was produced using ArchivesSpace on <date>2023-11-10 15:53:29 -0500</date>.</creation>
+      <langusage>Finding aid written in English</langusage>
+      <descrules>Describing Archives: A Content Standard</descrules>
+    </profiledesc>
+    <revisiondesc>
+      <change>
+        <date>September 2019</date>
+        <item>Updated by Jacqueline Rider for compliance with DACS and ACM Required Elements for Archival Description</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <archdesc level="collection">
+    <did>
+      <repository>
+        <corpname>New York University Archives</corpname>
+      </repository>
+      <unittitle>Thomas Clark Pollock Papers</unittitle>
+      <origination label="Creator">
+        <persname source="naf">Pollock, Thomas Clark, 1902-1988</persname>
+      </origination>
+      <unitid>MC.109</unitid>
+      <unitid type="aspace_uri">/repositories/6/resources/1930</unitid>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">0.25 Linear Feet</extent>
+        <extent altrender="carrier">in one half manuscript box</extent>
+      </physdesc>
+      <unitdate datechar="creation" normal="1963/1971" type="inclusive">1963-1971</unitdate>
+      <physloc id="aspace_c39575d9121d14a5edc6e0f756f24227">Materials are stored offsite and advance notice is required for use. Please request materials at least two business days prior to your research visit to coordinate access.</physloc>
+      <abstract id="aspace_bec536610173689324ba6b97bdb475f6">Thomas Clark Pollock (1902-1988) served New York University (NYU) as an education and English professor and as a department chair and dean. The collection consists of materials relating to Pollock's proposed 20th-century history of NYU.</abstract>
+      <langmaterial id="aspace_b20575192f29a0d1a925a1e1c7a02020">Materials are in English.</langmaterial>
+    </did>
+    <accessrestrict id="aspace_9c76db1073f1c2e4dce654438a88b8a2">
+      <head>Conditions Governing Access</head>
+      <p>Materials are open without restrictions.</p>
+    </accessrestrict>
+    <scopecontent id="aspace_14571b72c211595d895fc39a9d80aa9e">
+      <head>Scope and Contents</head>
+      <p>The collection consists of papers, published articles, drafts, correspondence and duplicates relating to Pollock's proposed 20th-century history of NYU.  Many of the papers are summaries of interviews Pollock conducted with faculty and administrators.</p>
+      <p>Pollock's manuscript, dated January 17, 1969, contains the results of his research and reading while he was studying background of the University for his proposed history of NYU. Bayrd Still, Pollock's successor as University Archivist, excerpted portions for the general reader and researcher under the title, "New York University in the Nineteenth Century."</p>
+    </scopecontent>
+    <arrangement id="aspace_6d13fee283cb4339a6e0f9c5f6249bf9">
+      <head>Arrangement</head>
+      <p>Items are arranged at the folder level.</p>
+    </arrangement>
+    <bioghist id="aspace_e5634c7321724369205f12357c30e92b">
+      <head>Biography</head>
+      <p>Thomas Clark Pollock (1902-1988) served on NYU's faculty and administration.  From 1941 to 1947, he was Professor of Education, becoming Chairman of the Department of English Education in 1944.  He was Professor of English and Dean of the Washington Square College of Arts and Science from 1947 to 1962.  In 1951, he took a one-year leave of absence from his deanship to become acting Provost of the University.  During that period he also served as Chief Administrator of the College of Dentistry.  From 1958 to 1959 he was Dean of the Graduate School of Arts and Science as well as Washington Square College.  In 1962 he was appointed Vice President and Secretary of the University.  In September 1967 he was appointed Archivist of the University, a position he held until March 1969.  He retired from NYU in 1970.</p>
+      <p>Pollock was awarded honorary degrees from Muskingum College and the Universities of Brazil and Bahia.</p>
+      <p>He wrote several books, including <emph render="italic">The Philadelphia Theatre in the Eighteenth Century, The Teaching of English Grammar in the Secondary Schools of New Jersey, The Nature of Literature, A Theory of Meaning Analyzed, The English Language in American Education</emph>, and <emph render="italic">Thomas Wolfe at Washington Square </emph>(with Oscar Cargill).  He was working on a 20th-century history of New York University at the time of his retirement.</p>
+    </bioghist>
+    <prefercite id="aspace_7c04e253b44b3d7e12a68af455d83e44">
+      <head>Preferred Citation</head>
+      <p>Identification of item, date (if known), T.C. Pollock Papers, MC 109, folder number, New York University Archives, New York University Libraries.</p>
+    </prefercite>
+    <userestrict id="aspace_7261c05166ab84c4148004e6a52161ca">
+      <head>Conditions Governing Use</head>
+      <p>Any rights (including copyright and related rights to publicity and privacy) held by the creator are maintained by New York University. Permission to publish or reproduce materials in this collection must be secured from New York University Archives, (212) 998-2646, university-archives@nyu.edu.</p>
+    </userestrict>
+    <acqinfo id="aspace_ce00559200da6557705f957c7647643b">
+      <head>Immediate Source of Acquisition</head>
+      <p>Materials found in collection; there is no documentation concerning the provenance of these materials.</p>
+    </acqinfo>
+    <processinfo id="aspace_f66c72a84bcb60af034e3d46b8030e77">
+      <head>Processing Information</head>
+      <p>Materials were placed in an archival box and folders.</p>
+    </processinfo>
+    <controlaccess>
+      <genreform source="aat">Manuscripts</genreform>
+      <genreform source="aat">Lecture notes.</genreform>
+      <subject source="lcsh">History.</subject>
+      <corpname authfilenumber="(lccn)n79052591" source="naf">New York University. Faculty of Arts and Science</corpname>
+      <corpname rules="dacs" source="local">New York University. Dean of Washington Square and University College</corpname>
+      <corpname authfilenumber="(lccn)n85271318" source="naf">New York University. College of Dentistry</corpname>
+      <corpname rules="dacs" source="local">New York University. Washington Square College of Arts and Science</corpname>
+      <corpname authfilenumber="(lccn)n80079860" source="naf">New York University. School of Education</corpname>
+      <corpname rules="dacs" source="local">New York University. Office of the Vice President and Secretary</corpname>
+    </controlaccess>
+    <dsc>
+      <c id="aspace_ref8" level="file">
+        <did>
+          <unittitle>New York University in the Nineteenth Century</unittitle>
+          <unitid type="aspace_uri">/repositories/6/archival_objects/594304</unitid>
+          <unitdate datechar="creation" normal="1969/1969" type="inclusive">1969</unitdate>
+          <langmaterial><language langcode="eng">English</language>.</langmaterial>
+          <container altrender="Manuscript box - Letter" id="aspace_9d7cb82870151a6bd11084a1e5284d15" label="Mixed Materials [31142063040987]" type="Box">1</container>
+          <container id="aspace_9e5a115e3efae71b8d27a41b1142f892" parent="aspace_9d7cb82870151a6bd11084a1e5284d15" type="Folder">1</container>
+        </did>
+      </c>
+      <c id="aspace_ref9" level="file">
+        <did>
+          <unittitle>Correspondence</unittitle>
+          <unitid type="aspace_uri">/repositories/6/archival_objects/594305</unitid>
+          <unitdate datechar="creation" normal="1966/1971" type="inclusive">1966-1971</unitdate>
+          <langmaterial><language langcode="eng">English</language>.</langmaterial>
+          <container altrender="Manuscript box - Letter" id="aspace_f762ef7b3b6f5b4a43b066e01bca7cfd" label="Mixed Materials [31142063040987]" type="Box">1</container>
+          <container id="aspace_83f6a5f182cc5fc8e3d7a53675c95a0b" parent="aspace_f762ef7b3b6f5b4a43b066e01bca7cfd" type="Folder">2</container>
+        </did>
+      </c>
+      <c id="aspace_ref10" level="file">
+        <did>
+          <unittitle>Duplicates of items in folders 1 and 4</unittitle>
+          <unitid type="aspace_uri">/repositories/6/archival_objects/594306</unitid>
+          <unitdate datechar="creation" normal="1963/1969" type="inclusive">1963-1969</unitdate>
+          <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
+          <container altrender="Manuscript box - Letter" id="aspace_edbab98ed95b8bdca0d8d7242adda487" label="Mixed Materials [31142063040987]" type="Box">1</container>
+          <container id="aspace_157acc69fd552ab5c6c4f0a3c2091678" parent="aspace_edbab98ed95b8bdca0d8d7242adda487" type="Folder">3</container>
+        </did>
+      </c>
+      <c id="aspace_ref11" level="file">
+        <did>
+          <unittitle>Plans and research for a History of New York University </unittitle>
+          <unitid type="aspace_uri">/repositories/6/archival_objects/594307</unitid>
+          <unitdate datechar="creation" normal="1963/1969" type="inclusive">1963-1969</unitdate>
+          <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
+          <container altrender="Manuscript box - Letter" id="aspace_870e47ca566b9f03ed773a0f18edfeda" label="Mixed Materials [31142063040987]" type="Box">1</container>
+          <container id="aspace_ca03b2584e54e718322c8b1e6a6af6e2" parent="aspace_870e47ca566b9f03ed773a0f18edfeda" type="Folder">4</container>
+        </did>
+      </c>
+    </dsc>
+  </archdesc>
+</ead>


### PR DESCRIPTION
# Overview
#### v0.31.0
  - Update `modify.FABifyEAD` code to remove the
    `<ead><archdesc><did><unitid @type="aspace_uri">` element from the
    EAD.  This is required because the FAB is currently appending the
    `aspace_uri` value to the `Collection call no:` result, e.g.,
    `Collection call no: MC.109/repositories/6/resources/1930`
