### PR TITLE
ead/modify/ -- updateContainerHierarchies(): fix `errors` append by moving format string and `rootID` into a `fmt.Sprintf`

### DIFF
--- a/ead/modify/modify.go
+++ b/ead/modify/modify.go
@@ -183,7 +183,7 @@ func updateContainerHierarchies(ctx *xpath.Context) []string {
 	for _, rootID := range rootIDs {
 		err := updateSubContainersUsingMap(subContainers, rootID, rootID)
 		if err != nil {
-			errors = append(errors, "error updating subcontainers of root container with @id=\"%s\"", rootID)
+			errors = append(errors, fmt.Sprintf("error updating subcontainers of root container with @id=\"%s\"", rootID))
 			return append(errors, err.Error())
 		}
 	}


### PR DESCRIPTION
99% sure this is a minor bug, but I don't know where the calling code is so can't check to see if it is expecting the errors slice to have format string and `rootID` be separate as opposed to used in an `fmt.Sprintf()`, but I'm guessing the `fmt.Sprintf()` was intended.